### PR TITLE
Add ONGOTO support

### DIFF
--- a/data/base/cartagrahd.py
+++ b/data/base/cartagrahd.py
@@ -1,5 +1,6 @@
 import core
 
+
 def IFN():
     # IFN (int, expr_str, {jump})
     core.read_uint16(True)
@@ -25,4 +26,13 @@ def JUMP():
     file = core.read_str(core.expr)
     if core.can_read():
         core.read_jump(file)
+    core.end()
+
+
+def ONGOTO():
+    # ONGOTO (expr, [<const_num>, label1, <const_num>, label2, ...])
+    core.read_len_str(core.Charset_UTF8)
+    while core.can_read():
+        core.read_uint16(False)
+        core.read_jump()
     core.end()

--- a/game/operator/opcode.go
+++ b/game/operator/opcode.go
@@ -154,7 +154,7 @@ func (op *OP) ReadFileJump(export bool, file string) uint32 {
 	if file != op.ctx.Script.Name &&
 		strings.ToUpper(file) != op.ctx.Script.Name &&
 		strings.ToLower(file) != op.ctx.Script.Name {
-		param.GlobalIndex = op.ctx.AddLabel(file, op.ctx.CIndex, int(val))
+		param.LabelIndex = op.ctx.AddLabel(file, op.ctx.CIndex, int(val))
 	}
 	op.params = append(op.params, Param{
 		Type:   "filejump",

--- a/script/entry.go
+++ b/script/entry.go
@@ -43,16 +43,21 @@ func (e *Entry) InitEntry() {
 }
 
 func (e *Entry) AddExportGotoLabel(codeIndex, pos int) int {
-
-	val, has := e.ELabelMap[pos]
-	if has {
-		e.EGotoMap[codeIndex] = val
-		return val
+	// if this offset has an assigned label, use it
+	if label, ok := e.ELabelMap[pos]; ok {
+		if _, used := e.EGotoMap[codeIndex]; !used {
+			e.EGotoMap[codeIndex] = label
+		}
+		return label
 	}
-	e.ELabelMap[pos] = e.IndexNext
-	e.EGotoMap[codeIndex] = e.IndexNext
+	// else create new label
+	label := e.IndexNext
+	e.ELabelMap[pos] = label
 	e.IndexNext++
-	return e.ELabelMap[pos]
+	if _, used := e.EGotoMap[codeIndex]; !used {
+		e.EGotoMap[codeIndex] = label
+	}
+	return label
 }
 
 // labelIndex, Goto参数位置

--- a/script/model.go
+++ b/script/model.go
@@ -12,9 +12,9 @@ type GlobalLabel struct {
 }
 
 type JumpParam struct {
-	GlobalIndex int
-	ScriptName  string
-	Position    int
+	LabelIndex int
+	ScriptName string
+	Position   int
 }
 
 type StringParam struct {


### PR DESCRIPTION
Luca System Engine has an ONGOTO instruction. It takes two args: a string for the variable name and an array of relatively offsets (from file start). It kinda sets a hook for those offsets. When interpreter hits any of them, it writes the offset's index (0 for first, 1 for second, etc) into the variable.
 
Not really sure what this is for. Mostly seen in third-party games (e.g. "Cartagra Tsuki Kurui no Yamai" and "Butterfly's Poison; Blood Chains"), where it’s called after every SELECT for no reason (maybe SDK example or smth). Since changing text changes offsets, the engine can’t read the instruction properly and throws an error (see issue [#19](https://github.com/wetor/LuckSystem/issues/19) & [#24](https://github.com/wetor/LuckSystem/issues/24#issuecomment-2873476395)).
This problem went unnoticed a long time because only VisualArts game using it is Little Busters.
 
Code changes are probably not very optimal, but I tested on several games and it works as expected.