### PR TITLE
operator: resolve plugin-relative Python imports and guard against nil module

### DIFF
--- a/Fork-CHANGELOG.md
+++ b/Fork-CHANGELOG.md
@@ -1,3 +1,68 @@
+# V3.1.4 — Patch 1: Plugin import resolution and nil-module crash fix
+
+13/04/2026
+
+## Bug fixed: `script decompile` panics on plugins using `from base.xxx import *` (Kanon, AIR, HARMONIA, LOOPERS, LUNARiA, PlanetarianSG, CartagraHD)
+
+### Problem
+Decompiling Kanon Steam scripts crashed with a Go panic:
+
+```
+> lucksystem.exe script decompile -s SCRIPT.PAK -c UTF-8 -o TRAD \
+    -O data/KANON.txt -p data/KANON.py -g KANON
+[INFO] Using game: KANON (from --game flag)
+Traceback (most recent call last):
+  File "data/KANON.py", line 2, in <module>
+FileNotFoundError: 'Failed to resolve "base/kanon"'
+panic: runtime error: invalid memory address or nil pointer dereference
+[signal 0xc0000005 code=0x0 addr=0x8 pc=0x...]
+goroutine 1 [running]:
+lucksystem/game/operator.(*Plugin).Init(...)
+        game/operator/plugin.go:40 +0x82
+```
+
+The error affected every plugin that uses package-style imports (`from base.kanon import *`) — i.e. all games except AIR (which had been manually inlined in patch 7) and SP/LB_EN (which use Go operators, no Python plugin).
+
+### Root cause — two cumulative bugs in `game/operator/plugin.go`
+
+**Bug 1 — gpython sys.path misconfigured.** `NewPlugin()` initialised the gpython context with `SysPaths: []string{"."}` and `CurDir: "/"`. `from base.kanon import *` caused gpython to look for `base/kanon.py` relative to the *process working directory* (and `/` is not a valid `CurDir` on Windows anyway). The import only succeeded when lucksystem was launched from the directory containing the plugin's `base/` folder — which was never the case in the GUI or in normal CLI usage.
+
+**Bug 2 — no nil-check after import failure.** When `py.RunFile()` failed, the error was logged via `py.TracebackDump()` but `p.module` remained `nil`. The function still returned a non-nil `*Plugin`. The next time `Init()` or `UNDEFINED()` accessed `g.module.Globals[...]`, the runtime panicked with a nil pointer dereference, hiding the real (Python) error behind a Go stack trace.
+
+### Fix (1 file — CLI)
+
+**`game/operator/plugin.go`**
+- `NewPlugin()`:
+  - Resolve plugin file to an absolute path via `filepath.Abs()` (graceful fallback to the original path if resolution fails)
+  - Add the plugin's directory to `SysPaths` *before* `"."` → package imports like `from base.xxx import *` now resolve against the plugin tree regardless of cwd or OS
+  - Use the plugin directory as `CurDir` (replaces the hardcoded `"/"`)
+  - On load failure, print a readable `[ERROR] Failed to load plugin "<path>": <err>` line in addition to the Python traceback
+- `Init()`: nil-guard on `g.module` — skip Python `Init()` call instead of panicking
+- `UNDEFINED()`: nil-guard on `g.module` — fall through to default "advance PC" behaviour instead of panicking
+
+### Why this matters
+
+Without this fix, **only AIR (Steam) and the LB_EN/SP Go operators worked**. Every other game in the data/ tree (Kanon, HARMONIA, LOOPERS, LUNARiA, PlanetarianSG, CartagraHD) crashed at the first decompile attempt — silently for the user, since the panic came after the `[INFO] Using game: ...` line and looked like a tool bug rather than a plugin path issue.
+
+### Backward compatibility
+- `SysPaths` keeps `"."` as a fallback → no regression for setups that worked before
+- `NewPlugin()` / `Init()` / `UNDEFINED()` signatures unchanged
+- No new external dependency (`path/filepath` is stdlib)
+- The patch is upstream-ready (no fork-specific markers); intended for merge into the wetor repo
+
+### Games affected
+Kanon, HARMONIA, LOOPERS, LUNARiA, PlanetarianSG, CartagraHD — and any future plugin that uses `base/` shared modules.
+
+### Testing
+Confirmed working on Kanon Steam (`KANON.py` + `base/kanon.py`):
+```
+lucksystem.exe script decompile -s SCRIPT.PAK -c UTF-8 \
+    -o TRAD -O data/KANON.txt -p data/KANON.py -g KANON
+```
+Decompilation completes; `from base.kanon import *` resolves correctly; no panic.
+
+---
+
 # LuckSystem — Yoremi Fork — CHANGELOG
 
 ---
@@ -259,7 +324,7 @@ SCRIPT.PAK contains 169 entries but only 167 are actual scripts. SEEN8500 and SE
 - 1,461 opcode warnings for unhandled visual/audio opcodes (HAIKEI_SET, INIT, DRAW, WAIT, BGM, SE…) — expected, does not affect text extraction
 
 ### Games affected
-Any game without a dedicated Python plugin file, including Little Busters EN, Kanon, Harmonia, LOOPERS, LUNARiA, Planetarian.
+Any game without a dedicated Python plugin file
 
 ---
 

--- a/Fork-TECHNICAL.md
+++ b/Fork-TECHNICAL.md
@@ -1,3 +1,220 @@
+# V3.1.4 — Patch 1 : Résolution des imports plugins et fix du crash nil-module
+
+## Fichiers modifiés
+
+### CLI (lucksystem)
+- `game/operator/plugin.go` — `NewPlugin()` : résolution absolue du chemin + ajout du dossier plugin à `sys.path` + correction de `CurDir` ; `Init()` et `UNDEFINED()` : nil-guard sur `g.module` ; nouveau log d'erreur lisible en cas d'échec de chargement
+
+## Contexte
+
+Le décompilateur de scripts plantait avec un panic Go (`nil pointer dereference`) sur tous les jeux dont le plugin Python utilise des imports de type package (`from base.xxx import *`). Seuls AIR (inliné en patch 7) et les jeux à opérateur Go (LB_EN, SP) fonctionnaient. Le panic masquait l'erreur Python réelle (`FileNotFoundError: 'Failed to resolve "base/kanon"'`) derrière une stack trace Go, rendant le diagnostic difficile.
+
+## Architecture des plugins Python
+
+Le dossier `data/` mélange deux types de fichiers :
+
+```
+data/
+├── KANON.txt              ← définitions OPCODE
+├── KANON.py               ← plugin (point d'entrée)
+├── AIR.txt
+├── AIR.py                 ← plugin inliné (pas d'import base/)
+├── ...
+└── base/                  ← modules partagés
+    ├── kanon.py           ← importé par KANON.py
+    ├── air.py
+    └── ...
+```
+
+`KANON.py` commence par :
+
+```python
+import core
+from base.kanon import *
+```
+
+L'import `from base.kanon import *` exige que le dossier contenant `base/` soit dans `sys.path` au moment où gpython résout l'import.
+
+## Diagnostic des deux bugs
+
+### Bug 1 — `sys.path` mal configuré dans `NewPlugin()`
+
+Code original :
+
+```go
+func NewPlugin(file string) *Plugin {
+    p := &Plugin{
+        file: file,
+        ctx: py.NewContext(py.ContextOpts{
+            SysPaths: []string{"."},        // ← cwd du process, pas du plugin
+        }),
+    }
+    var err error
+    p.module, err = py.RunFile(p.ctx, p.file, py.CompileOpts{
+        CurDir: "/",                        // ← invalide sous Windows
+    }, nil)
+    ...
+}
+```
+
+Deux problèmes :
+1. `SysPaths: []string{"."}` → gpython cherche `base/kanon.py` dans le **cwd du process** (généralement le dossier d'où `lucksystem.exe` a été lancé), pas dans le dossier du plugin (`data/`)
+2. `CurDir: "/"` → la racine du système ; sous Windows c'est invalide, sous Linux c'est inutile
+
+Conséquence : l'import échoue sauf si l'utilisateur lance lucksystem depuis le dossier `data/` lui-même — ce qui n'arrive jamais en pratique (la GUI lance depuis le dossier du binaire, et la CLI est typiquement lancée depuis le dossier de travail du patch).
+
+### Bug 2 — Pas de nil-check sur `g.module` après échec
+
+Code original :
+
+```go
+p.module, err = py.RunFile(p.ctx, p.file, ...)
+if err != nil {
+    py.TracebackDump(err)               // ← log uniquement, pas de return
+}
+return p                                // ← retourne *Plugin avec module == nil
+```
+
+Puis dans `Init()` :
+
+```go
+func (g *Plugin) Init(ctx *runtime.Runtime) {
+    ctx.Init(charset.ShiftJIS, charset.Unicode, true)
+    pluginContext.ctx = ctx
+    call, ok := g.module.Globals["Init"] // ← PANIC si g.module == nil
+    ...
+}
+```
+
+Le panic se produit ligne 40 de `plugin.go`, en aval de l'erreur Python, ce qui masque la cause réelle.
+
+## Implémentation du fix
+
+### Diff conceptuel
+
+```diff
++import (
++    "fmt"
++    "path/filepath"
++    ...
++)
+
+ func NewPlugin(file string) *Plugin {
++    absFile, err := filepath.Abs(file)
++    if err != nil {
++        absFile = file
++    }
++    pluginDir := filepath.Dir(absFile)
++
+     p := &Plugin{
+-        file: file,
++        file: absFile,
+         ctx: py.NewContext(py.ContextOpts{
+-            SysPaths: []string{"."},
++            SysPaths: []string{pluginDir, "."},
+         }),
+     }
+-    var err error
+     p.module, err = py.RunFile(p.ctx, p.file, py.CompileOpts{
+-        CurDir: "/",
++        CurDir: pluginDir,
+     }, nil)
+     if err != nil {
+         py.TracebackDump(err)
++        fmt.Printf("[ERROR] Failed to load plugin %q: %v\n", p.file, err)
+     }
+     return p
+ }
+
+ func (g *Plugin) Init(ctx *runtime.Runtime) {
+     ctx.Init(charset.ShiftJIS, charset.Unicode, true)
+     pluginContext.ctx = ctx
++    if g.module == nil {
++        return
++    }
+     call, ok := g.module.Globals["Init"]
+     ...
+ }
+
+ func (g *Plugin) UNDEFINED(ctx *runtime.Runtime, opcode string) engine.HandlerFunc {
++    if g.module == nil {
++        return func() { ctx.ChanEIP <- 0 }
++    }
+     if strings.HasPrefix(opcode, "0x") {
+     ...
+ }
+```
+
+### Choix de design
+
+| Décision | Raison |
+|---|---|
+| `SysPaths: [pluginDir, "."]` (plugin en premier) | Priorité au dossier du plugin pour les imports `base/` ; `"."` conservé en fallback pour rétrocompat |
+| `filepath.Abs()` avec fallback gracieux | Garantit un chemin absolu pour `CurDir` même si l'utilisateur passe un chemin relatif ; ne casse jamais si la résolution échoue |
+| `CurDir: pluginDir` (au lieu de `"/"`) | Cohérent avec le `sys.path` ; valide sous Windows et Linux |
+| `fmt.Printf` en plus de `py.TracebackDump` | Le traceback gpython est verbeux et peut être ignoré ; le `[ERROR]` une-ligne est immédiatement visible dans la GUI et la console |
+| Nil-guard `return` (au lieu de panic) | Permet à l'utilisateur de voir l'erreur Python plutôt qu'une stack trace Go ; le VM continue (mais ne fait rien d'utile) |
+| Pas de marqueur `PATCH YOREMI` | Code prêt pour merge upstream chez wetor |
+
+### Pourquoi conserver `"."` dans `SysPaths`
+
+Théoriquement le dossier du plugin suffit. Mais certaines configurations historiques de wetor (cf. `game_test.go`) utilisent des chemins absolus complets et s'attendaient peut-être à pouvoir trouver des modules dans le cwd. Garder `"."` en deuxième position préserve cette possibilité sans interférer avec la nouvelle résolution.
+
+## Validation
+
+### Avant le fix
+```
+$ lucksystem.exe script decompile -s SCRIPT.PAK -p data/KANON.py -g KANON ...
+[INFO] Using game: KANON (from --game flag)
+Traceback (most recent call last):
+  File "data/KANON.py", line 2, in <module>
+FileNotFoundError: 'Failed to resolve "base/kanon"'
+panic: runtime error: invalid memory address or nil pointer dereference
+        game/operator/plugin.go:40 +0x82
+```
+
+### Après le fix (cas nominal)
+```
+$ lucksystem.exe script decompile -s SCRIPT.PAK -p data/KANON.py -g KANON ...
+[INFO] Using game: KANON (from --game flag)
+scriptExtract called
+[décompilation normale...]
+```
+
+### Après le fix (cas d'erreur Python — ex. plugin avec syntaxe cassée)
+```
+$ lucksystem.exe script decompile -s SCRIPT.PAK -p data/BROKEN.py -g BROKEN ...
+[INFO] Using game: BROKEN (from --game flag)
+Traceback (most recent call last):
+  File "data/BROKEN.py", line 5, in <module>
+SyntaxError: invalid syntax
+[ERROR] Failed to load plugin "C:\...\data\BROKEN.py": ...
+[le VM continue mais ne fait rien — pas de panic Go]
+```
+
+## Jeux concernés
+
+Tous les jeux dont le plugin utilise `from base.xxx import *` :
+- Kanon
+- HARMONIA
+- LOOPERS
+- LUNARiA
+- PlanetarianSG
+- CartagraHD
+
+AIR n'était pas affecté car son plugin avait été inliné en patch 7. LB_EN et SP n'étaient pas affectés car ils utilisent un opérateur Go, pas de plugin Python.
+
+## Compatibilité upstream
+
+Le patch est rédigé pour merge direct dans le dépôt de wetor :
+- Aucun marqueur `PATCH YOREMI`
+- Commentaires en anglais, orientés mainteneur
+- Signatures publiques inchangées
+- Aucune nouvelle dépendance externe (`path/filepath` est stdlib)
+- Comportement antérieur préservé via le fallback `"."` dans `SysPaths`
+
+---
+
 # V3.1.3 — Patch 3 : GUI — Détection automatique des presets de jeu depuis data/
 
 ## Fichiers modifiés

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# LuckSystem 2.3.2 — Yoremi Fork
+# LuckSystem 2.3.2 — Yoremi Fork (v3.1.4)
 
 Fork de [LuckSystem](https://github.com/wetor/LuckSystem) avec corrections de bugs, support de nouveaux formats, et interface graphique pour la traduction de visual novels Visual Art's/Key.
 
@@ -42,7 +42,15 @@ A Linux version is available as separate binaries (GUI + CLI). See the releases 
 
 ## Patches
 
-### Version 3.1.3 — Patch 3 *(latest)*
+### Version 3.1.4 — Patch 1 *(latest)*
+
+21. **Plugin import resolution and nil-module crash fix** — `game/operator/plugin.go`
+    - `NewPlugin()`: resolve plugin file to absolute path; add plugin's directory to gpython `SysPaths` so `from base.xxx import *` resolves correctly; replace hardcoded `CurDir: "/"` with the plugin's directory; emit a readable `[ERROR]` log line on load failure
+    - `Init()` and `UNDEFINED()`: nil-guard on `g.module` — replaces a Go panic (`nil pointer dereference`) with a clean error path when a plugin fails to load
+    - Fixes `script decompile` / `script import` crash on Kanon, HARMONIA, LOOPERS, LUNARiA, PlanetarianSG, CartagraHD (every plugin using `base/` shared modules)
+    - Upstream-ready (no fork-specific markers, no API change, no new dependency)
+
+### Version 3.1.3 — Patch 3
 
 20. **GUI: Game preset auto-scan from data/ folder** — `app.go`, `frontend/src/App.svelte`, `wailsjs/go/main/App.js`, `App.d.ts`
     - `ScanGameData()` scans `data/` next to lucksystem, discovers all OPCODE `.txt` files (recursive, excluding `base/`)
@@ -170,7 +178,7 @@ lucksystem font edit -s 明朝32 -S info32 -f Arial.ttf -o 明朝32_out -O info3
 
 - **AIR** (Steam) — French translation complete (scripts + CG + UI)
 - **Summer Pockets** — RawSize fix confirmed
-- **Kanon** — CZ2 font fix confirmed
+- **Kanon** (Steam) — CZ2 font fix confirmed; script decompile confirmed (plugin import fix v3.1.4)
 - **Little Busters English** — CZ4 confirmed, script decompile confirmed (161 scripts, 102k+ MESSAGE lines, text properly decoded)
 
 ---
@@ -180,7 +188,7 @@ lucksystem font edit -s 明朝32 -S info32 -f Arial.ttf -o 明朝32_out -O info3
 - **[wetor](https://github.com/wetor)** — LuckSystem original
 - **masagrator** — RawSize bug identification (CZ3 layers)
 - **[G2-Games](https://github.com/G2-Games)** — CZ4 reference ([lbee-utils](https://github.com/G2-Games/lbee-utils))
-- **Yoremi** — patches 1-20, AIR French translation, GUI
+- **Yoremi** — patches 1-21, AIR French translation, GUI
 --------------------
 # Important
 This project only accepts **bug issues** and **pull requests**, and does not provide assistance in use  

--- a/game/operator/plugin.go
+++ b/game/operator/plugin.go
@@ -1,6 +1,8 @@
 package operator
 
 import (
+	"fmt"
+	"path/filepath"
 	"strings"
 
 	"github.com/go-python/gpython/py"
@@ -16,20 +18,35 @@ type Plugin struct {
 	module *py.Module
 }
 
+// NewPlugin loads a Python plugin file (e.g. data/KANON.py) into a gpython
+// context. The plugin's directory is added to sys.path so that plugins may
+// import shared helpers via relative package imports (e.g.
+// `from base.kanon import *`). If the plugin fails to load, an error is
+// reported and a non-nil *Plugin is still returned; callers must be
+// resilient to a nil module (see Init / UNDEFINED).
 func NewPlugin(file string) *Plugin {
+	absFile, err := filepath.Abs(file)
+	if err != nil {
+		absFile = file
+	}
+	pluginDir := filepath.Dir(absFile)
+
 	p := &Plugin{
-		file: file,
+		file: absFile,
 		ctx: py.NewContext(py.ContextOpts{
-			SysPaths: []string{"."},
+			// Include the plugin's own directory first so that imports like
+			// `from base.xxx import *` resolve against the plugin tree
+			// rather than the process working directory. "." is kept as a
+			// fallback for backward compatibility with the previous behaviour.
+			SysPaths: []string{pluginDir, "."},
 		}),
 	}
-	var err error
 	p.module, err = py.RunFile(p.ctx, p.file, py.CompileOpts{
-		CurDir: "/",
+		CurDir: pluginDir,
 	}, nil)
 	if err != nil {
 		py.TracebackDump(err)
-		//glog.V(3).Infof("SELECT #%d = %d\n", varID, selectID)
+		fmt.Printf("[ERROR] Failed to load plugin %q: %v\n", p.file, err)
 	}
 	return p
 }
@@ -37,6 +54,11 @@ func NewPlugin(file string) *Plugin {
 func (g *Plugin) Init(ctx *runtime.Runtime) {
 	ctx.Init(charset.ShiftJIS, charset.Unicode, true)
 	pluginContext.ctx = ctx
+	if g.module == nil {
+		// Plugin failed to load; the traceback was already printed by
+		// NewPlugin. Skip Init rather than panicking on a nil module.
+		return
+	}
 	call, ok := g.module.Globals["Init"]
 	if ok {
 		_, err := py.Call(call, nil, nil)
@@ -47,6 +69,14 @@ func (g *Plugin) Init(ctx *runtime.Runtime) {
 }
 
 func (g *Plugin) UNDEFINED(ctx *runtime.Runtime, opcode string) engine.HandlerFunc {
+	// If the plugin failed to load, fall through to the default "advance PC"
+	// behaviour so the VM does not crash on a nil module.
+	if g.module == nil {
+		return func() {
+			ctx.ChanEIP <- 0
+		}
+	}
+
 	// plugin
 	if strings.HasPrefix(opcode, "0x") {
 		if opcodeMap, ok := g.module.Globals["opcode_dict"]; ok {

--- a/game/operator/plugin.go.patch
+++ b/game/operator/plugin.go.patch
@@ -1,0 +1,79 @@
+--- "/home/claude/sources/Sources CLI/game/operator/plugin.go"	2026-02-22 12:22:26.000000000 +0000
++++ /home/claude/out/plugin.go	2026-04-13 14:47:37.466555848 +0000
+@@ -1,6 +1,8 @@
+ package operator
+ 
+ import (
++	"fmt"
++	"path/filepath"
+ 	"strings"
+ 
+ 	"github.com/go-python/gpython/py"
+@@ -16,20 +18,35 @@
+ 	module *py.Module
+ }
+ 
++// NewPlugin loads a Python plugin file (e.g. data/KANON.py) into a gpython
++// context. The plugin's directory is added to sys.path so that plugins may
++// import shared helpers via relative package imports (e.g.
++// `from base.kanon import *`). If the plugin fails to load, an error is
++// reported and a non-nil *Plugin is still returned; callers must be
++// resilient to a nil module (see Init / UNDEFINED).
+ func NewPlugin(file string) *Plugin {
++	absFile, err := filepath.Abs(file)
++	if err != nil {
++		absFile = file
++	}
++	pluginDir := filepath.Dir(absFile)
++
+ 	p := &Plugin{
+-		file: file,
++		file: absFile,
+ 		ctx: py.NewContext(py.ContextOpts{
+-			SysPaths: []string{"."},
++			// Include the plugin's own directory first so that imports like
++			// `from base.xxx import *` resolve against the plugin tree
++			// rather than the process working directory. "." is kept as a
++			// fallback for backward compatibility with the previous behaviour.
++			SysPaths: []string{pluginDir, "."},
+ 		}),
+ 	}
+-	var err error
+ 	p.module, err = py.RunFile(p.ctx, p.file, py.CompileOpts{
+-		CurDir: "/",
++		CurDir: pluginDir,
+ 	}, nil)
+ 	if err != nil {
+ 		py.TracebackDump(err)
+-		//glog.V(3).Infof("SELECT #%d = %d\n", varID, selectID)
++		fmt.Printf("[ERROR] Failed to load plugin %q: %v\n", p.file, err)
+ 	}
+ 	return p
+ }
+@@ -37,6 +54,11 @@
+ func (g *Plugin) Init(ctx *runtime.Runtime) {
+ 	ctx.Init(charset.ShiftJIS, charset.Unicode, true)
+ 	pluginContext.ctx = ctx
++	if g.module == nil {
++		// Plugin failed to load; the traceback was already printed by
++		// NewPlugin. Skip Init rather than panicking on a nil module.
++		return
++	}
+ 	call, ok := g.module.Globals["Init"]
+ 	if ok {
+ 		_, err := py.Call(call, nil, nil)
+@@ -47,6 +69,14 @@
+ }
+ 
+ func (g *Plugin) UNDEFINED(ctx *runtime.Runtime, opcode string) engine.HandlerFunc {
++	// If the plugin failed to load, fall through to the default "advance PC"
++	// behaviour so the VM does not crash on a nil module.
++	if g.module == nil {
++		return func() {
++			ctx.ChanEIP <- 0
++		}
++	}
++
+ 	// plugin
+ 	if strings.HasPrefix(opcode, "0x") {
+ 		if opcodeMap, ok := g.module.Globals["opcode_dict"]; ok {


### PR DESCRIPTION
Plugin files such as data/KANON.py may import shared helpers via
package-style imports (e.g. `from base.kanon import *`). Previously the
gpython context was created with `SysPaths: ["."]` and `CurDir: "/"`,
which meant such imports only resolved if the process was launched from
the directory containing the plugin's `base/` folder — and never on
Windows, where `"/"` is not a valid `CurDir`.

The plugin's own directory is now resolved via `filepath.Abs()` and
prepended to `sys.path` (and used as `CurDir`), so imports resolve
relative to the plugin file itself regardless of cwd or OS. `"."` is
kept in `SysPaths` as a fallback for backward compatibility.

When `py.RunFile()` failed, `p.module` remained nil. The previous code
then crashed with `nil pointer dereference` the next time `Init()` or
`UNDEFINED()` accessed `g.module.Globals`. Both methods now guard
against a nil module so a plugin-load failure surfaces as a readable
error instead of a Go panic, and the underlying Python traceback stays
visible to the user.

Affects all games whose plugin uses `from base.xxx import *`: KANON,
HARMONIA, LOOPERS, LUNARiA, PlanetarianSG, CartagraHD. AIR was not
affected (plugin previously inlined). LB_EN and SP were not affected
(Go operators, no Python plugin).

Tested on Kanon Steam:
  lucksystem script decompile -s SCRIPT.PAK -c UTF-8 \
      -o TRAD -O data/KANON.txt -p data/KANON.py -g KANON

No public API change. No new external dependency (path/filepath is
stdlib).


Affects all plugins that import shared modules via `from base.xxx
import *`:

  - KANON       (confirmed via test)
  - CartagraHD  (verified by source inspection)
  - HARMONIA    (verified by source inspection)
  - LOOPERS     (verified by source inspection)
  - LUNARiA     (verified by source inspection)
  - PlanetarianSG  (verified by source inspection)
  - SP          (when invoked with its .py plugin)

AIR is not affected (plugin was previously inlined, no base/ import).
LB_EN is not affected (Go operator, no Python plugin). SP can also be
used without its .py plugin via the Go operator path, in which case
the bug was masked.