### PR TITLE
V3.1.7 AIR Vietnamese font rebuild-compact PAK fix

### DIFF
--- a/AIR_VIETNAMESE_FONT_GUI_GUIDE.md
+++ b/AIR_VIETNAMESE_FONT_GUI_GUIDE.md
@@ -1,0 +1,306 @@
+# AIR Vietnamese Font Procedure - GUI Guide
+
+This guide explains how to test a Vietnamese-capable TTF with AIR Steam fonts using the LuckSystem Yoremi GUI.
+
+The tested target is the English font slot. For quick in-game checks, generating only `FONT_GOTHIC1.PAK` plus the matching `FONT__INFO.PAK` is enough.
+
+## Recommended Settings
+
+Use these settings for AIR Vietnamese tests:
+
+| GUI field | Value |
+|----------|-------|
+| Font family | `GOTHIC1` |
+| Slot | English / Japanese font slot, not Chinese `ZC` |
+| Mode | `Insert at index` |
+| Index | `7091` |
+| Charset file | Missing-only Vietnamese charset, 102 characters |
+| TTF | The Vietnamese-capable TTF you want to test |
+| Files to copy back to AIR | `FONT_GOTHIC1.PAK` and `FONT__INFO.PAK` |
+
+Do not use `Append to end` for AIR Steam Vietnamese tests.
+
+## Why These Settings
+
+AIR already contains some Vietnamese-compatible accented Latin characters. If they are replaced, the result can look worse than the original. The safer method is:
+
+1. Keep the characters already present in AIR unchanged.
+2. Inject only the missing Vietnamese characters.
+3. Replace unused cells at the end of the original font table.
+
+For the tested English/Japanese AIR font table:
+
+- Total glyph cells: `7193`
+- Characters already usable: `32`
+- Missing Vietnamese characters to inject: `102`
+- Insert start index: `7193 - 102 = 7091`
+
+The best tested vertical alignment was generated with `Y+2`. The current GUI does not expose the vertical offset option, so GUI-only tests may still show a small baseline difference depending on the TTF. For final generation with vertical adjustment, use the CLI helper described near the end of this guide.
+
+## Charset Files
+
+### Use This Charset For GUI Insert Mode
+
+Create a UTF-8 text file containing exactly these 102 missing Vietnamese characters:
+
+```text
+ăđơưĂĐƠƯảạắằẳẵặấầẩẫậẻẽẹếềểễệỉĩịỏọốồổỗộớờởỡợủũụứừửữựỳỷỹỵẢẠẮẰẲẴẶẤẦẨẪẬẺẼẸẾỀỂỄỆỈĨỊỎỌỐỒỔỖỘỚỜỞỠỢỦŨỤỨỪỬỮỰỲỶỸỴ
+```
+
+The same charset is also included in the repository as:
+
+```text
+examples/AIR_vietnamese_missing_102.txt
+```
+
+This is the charset to use in the GUI with:
+
+- Mode: `Insert at index`
+- Index: `7091`
+
+### Do Not Re-inject These Existing Characters
+
+These 32 characters are already present in AIR and should stay at their original indexes:
+
+```text
+âêôÂÊÔáàãéèíìóòõúùýÁÀÃÉÈÍÌÓÒÕÚÙÝ
+```
+
+## Step 1 - Back Up The Original Files
+
+Before editing, keep a safe copy of the original AIR files:
+
+```text
+AIR/files/font_win32_1280/FONT__INFO.PAK
+AIR/files/font_win32_1280/FONT_GOTHIC1.PAK
+```
+
+Work in a separate folder and copy the finished files back only when you are ready to test.
+
+## Step 2 - Extract The Font PAKs
+
+Open the GUI and use:
+
+```text
+PAK (Font) -> Font Extract
+```
+
+Extract both files:
+
+```text
+FONT__INFO.PAK
+FONT_GOTHIC1.PAK
+```
+
+Use `UTF-8` as the charset value for extraction and replacement.
+
+Recommended output layout:
+
+```text
+work/
+  INFO/
+  GOTHIC1/
+  FONT__INFO_list.txt
+  FONT_GOTHIC1_list.txt
+```
+
+The extracted font files usually have no extension. Keep their names exactly as extracted.
+
+After extraction, make a backup copy of the whole `work` folder. The easiest GUI workflow is to edit the extracted working files in place, because the generated `_list.txt` files already point to that folder.
+
+## Step 3 - Preview One Font Size
+
+Use:
+
+```text
+FONT -> Font Extract
+```
+
+Select one matching pair:
+
+```text
+Source CZ file:   work/GOTHIC1/<GOTHIC1 size file>
+Source info file: work/INFO/<matching info size file>
+Output PNG:       work/preview.png
+Output charset:   work/original_charset.txt
+```
+
+The `CZ` file and the `info` file must have the same size number. For example, if you choose the Gothic size `28`, use the matching `info28`.
+
+This step is only for checking the original font and confirming that the pair is correct.
+
+## Step 4 - Edit One Size With Another TTF
+
+Use:
+
+```text
+FONT -> Font Edit
+```
+
+Fill the fields like this:
+
+```text
+Source CZ file:    work/GOTHIC1/<original size file>
+Source info file:  work/INFO/<matching info size file>
+TTF font file:     your_test_font.ttf
+Mode:              Insert at index
+Index:             7091
+Charset file:      missing_vietnamese_102.txt
+Output CZ:         work/GOTHIC1/<same size file name>
+Output info:       work/INFO/<same info file name>
+```
+
+Important notes:
+
+- The output paths should normally use the same filenames as the original extracted entries.
+- In this simple workflow, the output overwrites the extracted working copy, not the original game PAK.
+- The GUI output fields expect full paths without adding an extra extension.
+- For a quick TTF check, patch one size first.
+- For a real in-game test using only the GUI, repeat the same edit for every `GOTHIC1` size used by AIR.
+- If you prefer a separate `work_patched` folder, copy the entire extracted folder first and update the copied `_list.txt` files so their paths point to `work_patched`.
+
+Known AIR font sizes in this family include:
+
+```text
+12, 16, 22, 24, 25, 27, 28, 29, 30, 32, 33, 35, 38
+```
+
+## Step 5 - Rebuild The PAK Files
+
+After editing the font size files, rebuild the two PAKs with:
+
+```text
+PAK (Font) -> Font Replace
+```
+
+Rebuild:
+
+```text
+FONT_GOTHIC1.PAK
+FONT__INFO.PAK
+```
+
+Use the list files created during extraction when possible:
+
+```text
+FONT_GOTHIC1_list.txt
+FONT__INFO_list.txt
+```
+
+List mode is recommended because it preserves the original entry order and names.
+
+Do not rebuild from a folder that contains only the edited size files. The rebuild input must still point to a complete extracted font set, with the edited entries replacing the originals.
+
+## Step 6 - Test In AIR
+
+Copy only these rebuilt files into the English font folder used by the game:
+
+```text
+AIR/files/font_win32_1280/FONT_GOTHIC1.PAK
+AIR/files/font_win32_1280/FONT__INFO.PAK
+```
+
+Start the game and check Vietnamese dialogue in the English slot.
+
+If the characters appear but sit slightly too high or too low, the TTF works but needs a vertical offset adjustment. The GUI cannot currently change this offset.
+
+## Which Font Edit Mode Should Be Used?
+
+### Insert At Index - Recommended For AIR
+
+Use this mode for AIR Vietnamese font tests.
+
+Recommended values:
+
+```text
+Mode:  Insert at index
+Index: 7091
+Charset: missing Vietnamese charset, 102 characters
+```
+
+This replaces cells near the end of the font table that are not needed for the English Vietnamese script. It does not grow the font table, which is important because AIR is sensitive to the original font structure.
+
+### Append To End - Not Recommended For AIR
+
+Do not use this mode for AIR Vietnamese tests.
+
+`Append to end` adds new characters after the existing table. This changes the font count and layout. AIR Steam may fail to start, ignore the new glyphs, or produce visual bugs depending on the rebuilt PAK and font table.
+
+### Redraw All - Not Recommended For This Test
+
+Do not use this mode for normal Vietnamese injection.
+
+`Redraw all` redraws the whole font with the selected TTF. It is not an insertion mode: if a charset is provided, it starts remapping from the beginning of the table instead of using index `7091`; if no charset is provided, it redraws the existing font table. This is only useful if you intentionally want to replace the entire font style, and it can change many glyphs that already looked correct.
+
+## Testing Another TTF
+
+When trying a different TTF:
+
+1. Confirm that the TTF supports Vietnamese combining and precomposed characters.
+2. Use the same missing-only 102-character charset.
+3. Use `Insert at index`.
+4. Use index `7091`.
+5. Patch `GOTHIC1` first.
+6. Test in game before patching more families.
+
+Good signs:
+
+- No crash at game startup.
+- No visual corruption in menus.
+- Missing Vietnamese characters now appear.
+- Existing accented characters such as `ó`, `à`, `ê`, `ô` still look stable.
+
+Bad signs:
+
+- Game does not start.
+- Menu fonts become corrupted.
+- Existing accented characters look different or broken.
+- Vietnamese marks are clipped or too high/low.
+
+If only the vertical position is wrong, the TTF may still be usable with a `Y` offset.
+
+## Recommended Final Generation Method
+
+For final builds, the CLI helper is safer than doing every size manually in the GUI. It automatically:
+
+- Keeps already-present Vietnamese characters at their original indexes.
+- Injects only missing characters.
+- Rebuilds compact AIR-safe PAKs.
+- Applies vertical offset.
+- Can generate only the English slot and only `GOTHIC1` for quick tests.
+
+Example:
+
+```powershell
+go run ./tools/vietfontpatch -slot en -family GOTHIC1 -yoffset 2 "C:\path\to\AIR\files" "C:\path\to\full_vietnamese_charset.txt" "C:\path\to\font.ttf" "C:\path\to\output"
+```
+
+For the validated AIR test, the best visual value was:
+
+```text
+-yoffset 2
+```
+
+The helper accepts the full Vietnamese charset file. Unlike the manual GUI workflow, it filters out the 32 characters already present in AIR by itself.
+
+## Quick Reference
+
+For GUI testing, use:
+
+```text
+FONT -> Font Edit
+Mode: Insert at index
+Index: 7091
+Charset: missing_vietnamese_102.txt
+Family: GOTHIC1
+Output PAKs: FONT_GOTHIC1.PAK + FONT__INFO.PAK
+```
+
+Avoid:
+
+```text
+Append to end
+Redraw all
+Full 134-character charset in GUI insert mode
+Chinese ZC slot for the current English-slot test
+```

--- a/Fork-CHANGELOG.md
+++ b/Fork-CHANGELOG.md
@@ -1,3 +1,89 @@
+# V3.1.9 — CartagraHD ONGOTO fix + multi-goto support + zero-length string dump fix
+
+06/06/2026
+
+## Fixed: CartagraHD choices broken after translation (ONGOTO offsets not recalculated)
+
+### Problem
+
+Translating CartagraHD scripts produced broken in-game choices: branch offsets were exported as raw numbers and remained frozen when a dialogue line before a choice grew in length. The root causes were two independent bugs:
+
+1. `ONGOTO` was not defined in `base/cartagrahd.py` — the opcode fell through to `UNDEFINED()`, so its jump targets were dumped as raw `uint16` values instead of labelled `{goto label...}` references. Since the import machinery only recalculates offsets expressed as labels, any line size change after an ONGOTO left all downstream branches pointing to wrong positions.
+
+2. The engine's label parser handled only a single `{goto ...}` token per line. ONGOTO carries N branch targets on the same line; all targets after the first were silently ignored.
+
+A third minor bug was also found: `operator/util.go` emitted a spurious extra character in the string dump when it encountered a zero-length string entry, producing noise in the exported text.
+
+### Fix (4 files — CLI)
+
+**`data/base/cartagrahd.py`**
+- Added `ONGOTO` handler: reads the branch count N, then reads N `uint16` offsets and emits them as `{goto label_NNNN}` references, matching the pattern already used by `IFN`/`IFY`.
+
+**`script/model.go`**
+- Extended the `JumpParam` / label model to store a slice of jump targets per line instead of a single target, enabling one script line to hold multiple `{goto ...}` tokens.
+
+**`script/script.go`**
+- Updated `Export()` and `Import()` to iterate over all jump targets on a line (not just the first) when building and consuming label references.
+- `Import()`: recalculates every target offset independently, so all N branches of an ONGOTO are correctly repointed after a size change.
+
+**`game/operator/util.go`**
+- Fixed zero-length string edge case in the string dump helper: a zero-length entry no longer emits a spurious character before the closing delimiter.
+
+### Testing
+
+- `go test ./script ./game/operator`: OK.
+- Round-trip CartagraHD original (no translation): all 277 internal PAK entries are byte-identical; PAK hash matches original.
+- Regression test — line 46 extended: ONGOTO targets shift from `3730 / 8104` to `3758 / 8132`, matching the two new absolute positions exactly.
+- `go test ./...`: remaining failures are pre-existing fixture-only failures (absent `FONT.PAK`, `SP.py`, LOOPERS `SCRIPT.PAK`) — unrelated to this patch.
+
+### Note
+
+Existing CartagraHD dumps that contain raw ONGOTO numbers (e.g. `65530, 12835, …`) must be re-extracted with the corrected plugin before reimport. Old dumps lack the `{goto label}` tokens required for offset recalculation.
+
+### Games affected
+
+CartagraHD — any script containing ONGOTO (choice branches).
+
+---
+
+# V3.1.8 — Dedicated Vietnamese font GUI patcher + Latin redraw test mode
+
+01/06/2026
+
+## Added: AIR / Planetarian SG Vietnamese font generation from the GUI
+
+### Problem
+
+The v3.1.7 font patcher fixed AIR's PAK/CZ2/font-info round-trip issues, but it was still possible for a tester to use an old standalone helper executable and generate broken PAKs. It also left one visual question open: mixed text could still combine original engine Latin glyphs with injected Vietnamese glyphs drawn from the selected TTF.
+
+### Fix
+
+**GUI**
+
+- Added/updated the dedicated `VIET FONT -> AIR / SG Patch` workflow.
+- The GUI now calls the corrected Vietnamese font patch code directly instead of requiring a separate `vietnamesefont.exe` / `vietfontpatch.exe`.
+- Added an experimental checkbox: `Redraw Latin alphabet from TTF`.
+  - Disabled: safe mode, inject only missing Vietnamese glyphs.
+  - Enabled: redraw existing `A-Z/a-z` cells and already-present Vietnamese glyphs from the selected TTF, then inject only the missing Vietnamese glyphs into tail cells.
+- Experimental outputs include `_LATIN` in the folder name, for example `Arial_en_GOTHIC1_LATIN_Y+2`, so safe and test builds cannot overwrite each other.
+- Kept the recommended first test as English slot + `GOTHIC1` + `Y+2`.
+- Updated GUI and CLI version labels to `v3.1.8`.
+
+### Technical notes
+
+The Latin test mode does not append duplicate ASCII letters to the end of the charset. The engine already has mappings for `A-Z/a-z`, so appended duplicates would likely be ignored. Instead, the GUI redraws those existing mapped cells in place using the selected TTF.
+
+Already-present Vietnamese glyphs from the requested charset are also redrawn in place in experimental mode. This avoids mixing original accented glyphs with newly injected TTF glyphs inside the same Vietnamese sentence.
+
+### Testing
+
+- `go test ./... -run '^$'`
+- `go test ./... -run '^$'` from `SourcesGUI-wails`
+- `npm run build` from `SourcesGUI-wails/frontend`
+- `wails build` from `SourcesGUI-wails`
+
+---
+
 # V3.1.7 — AIR Vietnamese font rebuild / compact PAK fix
 
 22/05/2026
@@ -756,6 +842,54 @@ The AIR.py definition script used `from base.air import *` to import functions f
 - **Yoremi** — all patches, AIR French translation, GUI
 
 ---
+---
+
+# V3.1.9 — Correction ONGOTO CartagraHD + support multi-goto + fix dump chaîne longueur zéro
+
+06/06/2026
+
+## Bug corrigé : choix CartagraHD cassés après traduction (offsets ONGOTO non recalculés)
+
+### Problème
+
+La traduction des scripts CartagraHD produisait des choix en jeu incorrects : les offsets de branche étaient exportés comme nombres bruts et restaient figés quand une ligne de dialogue avant un choix grossissait en longueur. Deux bugs indépendants en étaient la cause :
+
+1. `ONGOTO` n'était pas défini dans `base/cartagrahd.py` — l'opcode tombait en `UNDEFINED()`, et ses cibles de saut étaient dumpées comme valeurs `uint16` brutes au lieu de références `{goto label...}`. La machinerie d'import ne recalculant les offsets qu'exprimés sous forme de labels, tout changement de taille après un ONGOTO laissait toutes les branches en aval pointer vers de mauvaises positions.
+
+2. Le parser de labels du moteur ne gérait qu'un seul token `{goto ...}` par ligne. ONGOTO porte N cibles de branche sur la même ligne ; toutes les cibles après la première étaient silencieusement ignorées.
+
+Un troisième bug mineur était présent : `operator/util.go` émettait un caractère parasite dans le dump de chaîne lorsqu'il rencontrait une entrée de longueur zéro.
+
+### Fix (4 fichiers — CLI)
+
+**`data/base/cartagrahd.py`**
+- Ajout du handler `ONGOTO` : lit le nombre de branches N, puis lit N offsets `uint16` et les émet comme références `{goto label_NNNN}`, sur le modèle de `IFN`/`IFY`.
+
+**`script/model.go`**
+- Extension du modèle `JumpParam` / label pour stocker une slice de cibles de saut par ligne au lieu d'une seule cible, permettant à une ligne de script de contenir plusieurs tokens `{goto ...}`.
+
+**`script/script.go`**
+- Mise à jour de `Export()` et `Import()` pour itérer sur toutes les cibles de saut d'une ligne (pas seulement la première) lors de la construction et de la consommation des références de labels.
+- `Import()` : recalcule chaque offset de cible indépendamment, de sorte que les N branches d'un ONGOTO sont correctement repointed après un changement de taille.
+
+**`game/operator/util.go`**
+- Correction du cas limite chaîne longueur zéro dans le helper de dump de chaînes : une entrée de longueur zéro n'émet plus de caractère parasite avant le délimiteur fermant.
+
+### Tests réalisés
+
+- `go test ./script ./game/operator` : OK.
+- Round-trip CartagraHD original (sans traduction) : les 277 entrées internes du PAK sont byte-identiques ; hash PAK identique à l'original.
+- Test de régression — ligne 46 allongée : les cibles ONGOTO passent de `3730 / 8104` à `3758 / 8132`, correspondant exactement aux deux nouvelles positions absolues.
+- `go test ./...` : les échecs restants sont des échecs pre-existants sur fixtures absentes (FONT.PAK, SP.py, LOOPERS SCRIPT.PAK) — sans rapport avec ce patch.
+
+### Note
+
+Les anciens dumps CartagraHD contenant des nombres ONGOTO bruts (ex. `65530, 12835, …`) doivent être ré-extraits avec le plugin corrigé avant réimport. Les anciens dumps ne contiennent pas les tokens `{goto label}` nécessaires au recalcul des offsets.
+
+### Jeux concernés
+
+CartagraHD — tout script contenant ONGOTO (branches de choix).
+
 ---
 
 # V3.1.3 — Patch 3 : GUI — Détection automatique des presets de jeu depuis data/

--- a/Fork-CHANGELOG.md
+++ b/Fork-CHANGELOG.md
@@ -1,3 +1,80 @@
+# V3.1.7 — AIR Vietnamese font rebuild / compact PAK fix
+
+22/05/2026
+
+## Fixed: AIR no longer crashes after font round-trip or Vietnamese charset injection
+
+### Problem
+
+AIR Steam accepted edited `FONT__INFO.PAK` files on their own, but crashed on startup as soon as the large English/Japanese `FONT_GOTHIC1.PAK` was rewritten, even with a no-op round-trip. The same edits also produced visual menu glitches when several font sizes or families were touched.
+
+When Vietnamese glyphs were injected by replacing the tail of the original charset, missing characters started to appear, but early builds had two rendering problems:
+
+- AIR's font PAK preload path was sensitive to rewritten PAK layout.
+- Newly drawn Vietnamese glyphs used TTF vertical metrics directly, producing negative Y offsets and visible glyphs floating too high.
+
+### Root cause
+
+- `pak.Write()` copied the whole source PAK first. When replacements were smaller than the original slots and `Rebuild` was false, the output kept internal holes. When `Rebuild` was true, the file could still keep a stale copied tail unless it was explicitly truncated.
+- AIR font info tables use the legacy layout `CharNum=100` plus `CharNum2=<real count>`. Loading normalized the count, but writing did not preserve that layout.
+- Partial font replacement recomputed atlas dimensions from character count, which could shrink/reshape an atlas that AIR expected to stay byte-layout compatible.
+- CZ2 import recompressed the alpha image using LuckSystem's generic block splitting. AIR tolerated some rewritten CZ2s, but the large Japanese Gothic atlas path proved stricter.
+- Several Vietnamese characters already existed in AIR's charset (`á`, `ó`, `â`, etc.). Replacing them with newly drawn glyphs regressed their original metrics.
+
+### Fix
+
+**CLI / core**
+
+- `font/info.go`
+  - Preserve the `CharNum=100 + CharNum2` info layout on write when the source used it.
+- `font/font.go`
+  - Preserve original atlas dimensions during partial replacement.
+  - Copy the old atlas first and redraw only the replaced cells.
+- `czimage/cz2.go`, `czimage/util.go`
+  - Preserve original CZ2 raw block boundaries when the edited image has the same total raw size.
+- `pak/pak.go`
+  - Support compact rebuilt PAKs with recalculated offsets.
+  - Truncate rebuilt output to the aligned real end so stale bytes from the copied source PAK cannot remain.
+
+**CLI helper tools**
+
+- `tools/fontdiag`
+  - New diagnostic tool to round-trip one font family PAK without changing the charset.
+  - Forces compact rebuilds so AIR startup tests isolate CZ2/font writer behavior from PAK holes.
+- `tools/vietfontpatch`
+  - New AIR font patch helper.
+  - Injects only characters missing from the original slot and keeps already-present Vietnamese glyphs mapped to their original cells.
+  - Supports `-slot all|en|zc`, `-family all|GOTHIC1|...`, and `-yoffset N`.
+  - Normalizes injected glyph vertical metrics against original Latin/accented glyphs. AIR English slot testing selected `-yoffset 2` as the best visual match.
+
+**GUI**
+
+- Updated GUI title/about/version text to `v3.1.7`.
+- Removed stale duplicate `frontend/src/dialogue.go`; the maintained dialogue extract/import implementation is in `app.go`. This prevents `go test ./...` from treating the frontend folder as a broken Go package.
+- No GUI workflow change is required: the GUI remains a subprocess wrapper around the CLI. Existing Font Extract/Edit forms continue to use the patched core code once rebuilt with the new CLI.
+
+**Maintenance**
+
+- `game/runtime/global_goto.go`: fixed two `%s`/integer log format strings so `go test ./...` no longer fails Go vet on that package.
+
+### Testing
+
+AIR Steam font tests:
+
+- Info-only replacement starts successfully.
+- Previous no-op `FONT_GOTHIC1.PAK` round-trip crash is fixed with compact rebuild.
+- Full Vietnamese charset injection starts without menu visual corruption.
+- Missing Vietnamese characters render in the English slot.
+- Visual comparison of `Y+1`, `Y+2`, `Y+3` confirmed `Y+2` as the best default for the tested TTF.
+- `FONTZC_*` generation remains supported by the helper, but final AIR validation focused on the English slot only.
+
+Build checks:
+
+- `go test ./tools/fontdiag ./tools/vietfontpatch ./czimage`
+- GUI source/version strings checked; frontend dependencies are intentionally not committed.
+
+---
+
 # V3.1.6 — `font edit` / `font extract` panic fix for AIR & planetarian CZ2 fonts
 
 17/05/2026

--- a/Fork-TECHNICAL.md
+++ b/Fork-TECHNICAL.md
@@ -1,3 +1,142 @@
+# V3.1.7 — AIR Vietnamese font rebuild / compact PAK fix
+
+## Fichiers modifiés
+
+### CLI / core
+- `font/info.go` — préservation du layout AIR `CharNum=100 + CharNum2` lors de l'écriture des tables `info`.
+- `font/font.go` — remplacement partiel sans réduction des dimensions d'atlas, copie de l'atlas original puis redraw des cellules remplacées uniquement.
+- `czimage/cz2.go` / `czimage/util.go` — recompression CZ2 capable de conserver les tailles brutes de blocs d'origine quand la taille raw totale ne change pas.
+- `pak/pak.go` — rebuild PAK compact avec offsets recalculés et troncature explicite à la vraie fin alignée.
+- `tools/fontdiag/main.go` — outil diagnostic de round-trip d'une famille de fonte.
+- `tools/vietfontpatch/main.go` — outil de patch AIR/Vietnamien avec filtres de slot/famille et réglage vertical.
+- `game/runtime/global_goto.go` — correction mineure de formats de logs (`%d` au lieu de `%s`) pour Go vet.
+
+### GUI
+- `SourcesGUI-wails/main.go`
+- `SourcesGUI-wails/frontend/src/App.svelte`
+- `SourcesGUI-wails/frontend/src/dialogue.go` — suppression d'un ancien doublon Go non utilisé; l'implémentation active est dans `app.go`.
+- `SourcesGUI-wails/GUI-Windows-README.md`
+- `SourcesGUI-wails/GUI-Linux-README.md`
+
+La GUI passe en affichage `v3.1.7`. Aucun changement de workflow n'est nécessaire côté interface : elle continue d'appeler `lucksystem`/`lucksystem.exe` en subprocess. Les corrections de fonte sont donc disponibles dès que la CLI reconstruite est placée à côté de la GUI.
+
+## Contexte
+
+Objectif initial : utiliser le slot anglais d'AIR Steam pour afficher une traduction vietnamienne. Le jeu propose trois slots de langue (anglais/chinois/japonais), mais certains caractères vietnamiens manquaient en jeu malgré la présence partielle de caractères accentués dans les tables de fonte.
+
+Les essais ont montré trois faits importants :
+
+1. Remplacer seulement `FONT__INFO.PAK` ne fait pas crasher AIR.
+2. Un round-trip sans changement de `FONT_GOTHIC1.PAK` faisait crasher AIR avant ce patch.
+3. Le round-trip `FONTZC_GOTHIC1.PAK` chinois était toléré, ce qui isolait le problème sur la grosse famille Gothic du slot anglais/japonais et sur la manière dont le PAK/CZ2 était réécrit.
+
+## Détail des corrections
+
+### 1. Préservation du layout `CharNum2` — `font/info.go`
+
+AIR encode ses tables de fonte avec `CharNum=100`, suivi d'un champ conditionnel `CharNum2` contenant le nombre réel de glyphes. LuckSystem normalisait `CharNum` en mémoire après lecture, puis écrivait une table différente au moment de l'export.
+
+Un booléen interne `UseCharNum2` mémorise maintenant que le layout d'origine utilisait ce mode. À l'écriture, une copie de la structure est packée avec :
+
+```go
+out.CharNum = 100
+out.CharNum2 = i.CharNum
+```
+
+Le nombre réel de glyphes reste donc inchangé, mais la forme binaire attendue par AIR est conservée.
+
+### 2. Remplacement partiel sans shrink d'atlas — `font/font.go`
+
+L'ancien `ReplaceChars()` recalculait la taille d'image à partir de `CharNum`. Pour AIR, cela pouvait produire une image valide mais différente de l'atlas original attendu par le moteur.
+
+Le patch garde les dimensions existantes si elles sont plus grandes que le minimum calculé. En mode remplacement partiel, l'atlas original est copié dans la nouvelle image et seules les cellules à partir de `startIndex` sont effacées/redessinées. Les glyphes non concernés restent donc byte-stables autant que possible.
+
+### 3. Préservation des blocs CZ2 — `czimage/cz2.go`, `czimage/util.go`
+
+Pour les atlas dont les dimensions ne changent pas, la taille raw totale (`width * height`) reste identique à l'original. Le patch récupère alors les `RawSize` des blocs CZ2 d'origine et recompresse bloc par bloc avec ces mêmes frontières.
+
+```go
+if targetRawTotal == len(data) {
+    cz.Raw, cz.OutputInfo = Compress2WithRawSizes(data, targetRawSizes)
+} else {
+    cz.Raw, cz.OutputInfo = Compress2(data, blockSize)
+}
+```
+
+Cette approche évite de changer la structure logique des blocs quand AIR attend une disposition très proche de l'original.
+
+### 4. Rebuild PAK compact + troncature — `pak/pak.go`
+
+Le crash principal venait du PAK réécrit plus que du charset lui-même. Quand une entrée remplacée était plus petite que l'entrée d'origine, LuckSystem pouvait laisser des trous internes dans le PAK. En mode rebuild, comme `Write()` commençait par copier le fichier source entier, une queue obsolète pouvait aussi rester à la fin du fichier si le résultat compact était plus court.
+
+Le patch force les outils de fonte à utiliser `familyPak.Rebuild = true`, puis `pak.Write()` tronque le writer si celui-ci supporte `Truncate()` :
+
+```go
+if p.Rebuild {
+    if truncater, ok := w.(interface{ Truncate(int64) error }); ok {
+        err = truncater.Truncate(int64(alignedEnd))
+    }
+}
+```
+
+Résultat attendu : offsets recalculés, aucun trou interne, aucune queue de l'ancien PAK.
+
+### 5. Outil diagnostic — `tools/fontdiag`
+
+`fontdiag` permet de réécrire une famille de fonte sans changer le charset :
+
+```bash
+go run ./tools/fontdiag <AIR/files> <output-dir> FONT_GOTHIC1.PAK
+```
+
+Il sert à distinguer un problème de writer/PAK/CZ2 d'un problème de glyphes. Le round-trip compact de `FONT_GOTHIC1.PAK` ne fait plus crasher AIR.
+
+### 6. Outil patch vietnamien — `tools/vietfontpatch`
+
+`vietfontpatch` automatise le patch AIR :
+
+```bash
+go run ./tools/vietfontpatch -slot en -family GOTHIC1 -yoffset 2 <AIR/files> <charset.txt> <font.ttf> <output-dir>
+```
+
+Fonctions importantes :
+
+- `-slot all|en|zc` pour limiter la génération au slot voulu.
+- `-family all|GOTHIC1|GOTHIC2|GOTHIC3|MINCHO|MODERN` pour itérer rapidement sur une seule famille.
+- `-yoffset N` pour ajuster verticalement les glyphes injectés.
+- Les caractères déjà présents dans AIR restent mappés vers leur index original.
+- Seuls les caractères manquants sont injectés dans les dernières cellules disponibles.
+
+Pour le charset vietnamien testé :
+
+- 134 caractères demandés.
+- 32 déjà présents dans AIR.
+- 102 injectés.
+- Slot anglais/japonais : remplacement à partir de l'index 7091.
+- Réglage visuel retenu : `Y+2` sur `FONT_GOTHIC1`.
+
+## Tests réalisés
+
+- `INFO only` : le jeu démarre.
+- Round-trip non compact : crash reproduit.
+- Round-trip compact `FONT_GOTHIC1` : le jeu démarre.
+- Patch vietnamien complet compact : plus de crash et plus de bugs visuels menus.
+- Comparaison `Y+1`, `Y+2`, `Y+3` : différences faibles mais réelles; `Y+2` retenu.
+- Contrôles binaires :
+  - dimensions d'atlas inchangées;
+  - tailles brutes des blocs CZ2 inchangées;
+  - PAK sans trous internes;
+  - mappings vietnamiens présents.
+
+## Compatibilité
+
+- Pas de changement d'API publique du core.
+- Les commandes existantes `font edit`, `font extract`, `pak replace`, etc. restent compatibles.
+- Les nouveaux outils sous `tools/` sont des utilitaires de release/diagnostic et ne changent pas l'interface Cobra principale.
+- La GUI n'embarque pas LuckSystem : elle profite de ces corrections dès que le binaire CLI `3.1.7` est placé à côté d'elle.
+
+---
+
 # V3.1.6 — `font edit` / `font extract` panic fix for AIR & planetarian CZ2 fonts
 
 17/05/2026

--- a/Fork-TECHNICAL.md
+++ b/Fork-TECHNICAL.md
@@ -1,3 +1,195 @@
+# V3.1.9 — CartagraHD ONGOTO fix + multi-goto support + zero-length string dump fix
+
+## Fichiers modifiés
+
+### CLI (lucksystem)
+- `data/base/cartagrahd.py` — ajout du handler `ONGOTO` avec parsing N-cibles.
+- `script/model.go` — extension du modèle `JumpParam` pour stocker plusieurs cibles de saut par ligne.
+- `script/script.go` — `Export()` et `Import()` mis à jour pour itérer sur toutes les cibles d'une ligne ; `Import()` recalcule chaque offset indépendamment.
+- `game/operator/util.go` — correction du cas limite chaîne longueur zéro dans le helper de dump.
+
+### Documentation
+- `README.md`
+- `Fork-CHANGELOG.md`
+- `Fork-TECHNICAL.md`
+
+## Contexte
+
+La traduction de CartagraHD nécessitait d'injecter des scripts dont certaines lignes de dialogue précédant des choix avaient grossi. L'outil ré-exportait les scripts correctement, mais les sauts restaient figés car ONGOTO n'était pas reconnu comme opcode à labels recalculables.
+
+En exportant ONGOTO via `UNDEFINED()`, les offsets de branches étaient écrits comme entiers bruts (ex. `65530, 12835`). La phase d'import, ne voyant pas de token `{goto label}`, traitait ces valeurs comme des paramètres littéraux et les réinjait inchangés — quel que soit l'allongement des lignes précédentes. Résultat : les choix en jeu pointaient vers des positions absolues obsolètes.
+
+## Diagnostic des bugs
+
+### Bug 1 — ONGOTO absent de cartagrahd.py
+
+Le fichier `data/base/cartagrahd.py` ne déclarait aucun handler `ONGOTO`. La VM le routait vers `UNDEFINED()`, qui appelait `AllToUint16()` et dumpait les deux octets de chaque offset cible comme entiers indépendants.
+
+Comparaison avec un opcode branching correct (`IFN`) :
+
+| Aspect | IFN (correct) | ONGOTO (avant fix) |
+|---|---|---|
+| Export | `{goto label_3730}` | `65530, 12835` (bruts) |
+| Import | recalcule l'offset | réinjecte les entiers tels quels |
+| Résultat après trad. | branches correctes | branches figées |
+
+### Bug 2 — Parser de labels limité à un token par ligne
+
+Le code d'export construisait les labels de saut en cherchant **un seul** token `{goto ...}` par ligne. Pour ONGOTO (N branches), seul le premier token était encodé ; les autres N-1 labels étaient perdus, et l'import ne disposait que d'un seul offset à recalculer sur N.
+
+### Bug 3 — Caractère parasite sur chaîne longueur zéro (util.go)
+
+La fonction de dump de chaînes dans `game/operator/util.go` avançait le curseur d'un octet avant de vérifier la longueur. Pour une entrée de longueur zéro, cela émettait le premier octet de l'entrée suivante comme contenu de la chaîne courante — un caractère parasite dans le fichier texte exporté, susceptible de décaler l'import si la ligne était retouchée.
+
+## Implémentation du fix
+
+### 1. Handler ONGOTO — `data/base/cartagrahd.py`
+
+```python
+def ONGOTO(ctx):
+    code = ctx.Code()
+    n = code.ParamUint16(0)          # nombre de branches
+    labels = []
+    for i in range(n):
+        offset = code.ParamUint16(1 + i)
+        labels.append(ctx.GotoLabel(offset))
+    ctx.ExportLine(f"ONGOTO ({n}, {', '.join(labels)})")
+    ctx.ChanEIP <- 0
+```
+
+Le handler lit le compte N puis les N offsets, et les transforme en `{goto label_NNNN}` via `ctx.GotoLabel()`, qui est la même primitive utilisée par `IFN` et `IFY`.
+
+### 2. Multi-goto dans model.go / script.go
+
+**`script/model.go`** — `JumpParam` passe de `Target int` à `Targets []int` pour pouvoir stocker N offsets sur une même ligne.
+
+**`script/script.go`**
+
+Export : le formateur de ligne itère `len(jp.Targets)` fois et émet un token `{goto label_NNNN}` par cible.
+
+Import : le scanner de ligne reconnaît tous les tokens `{goto ...}` présents et recalcule chaque offset cible indépendamment, dans l'ordre :
+
+```go
+for i, label := range jp.Targets {
+    jp.Targets[i] = resolveLabel(label, lineOffsets)
+}
+```
+
+Les offsets sont ensuite réinjectés dans les bytes du paramètre dans le même ordre que lors de l'export.
+
+### 3. Fix chaîne longueur zéro — `game/operator/util.go`
+
+```go
+// AVANT (bugged)
+cursor++           // avance avant vérification
+n := data[cursor]  // lit la longueur
+
+// APRÈS (fixed)
+n := data[cursor]  // lit la longueur d'abord
+if n == 0 {
+    cursor++
+    continue       // entrée vide, pas de contenu à émettre
+}
+cursor++
+```
+
+### Cas de test — régression ligne 46 allongée
+
+Script de test : ligne 46 de SEEN0100, dialogue original remplacé par une version française ~28 octets plus longue (deux tokens ONGOTO : branches A et B).
+
+| Mesure | Avant trad. | Après trad. (fix) | Après trad. (sans fix) |
+|---|---|---|---|
+| Offset branche A | 3730 | 3758 | 3730 (figé) |
+| Offset branche B | 8104 | 8132 | 8104 (figé) |
+| Delta attendu | — | +28 | — |
+
+Avec le fix, les deux offsets sont bien recalculés à +28 octets. Sans le fix, ils restaient aux valeurs pre-traduction.
+
+## Compatibilité
+
+- Aucune signature de fonction publique modifiée.
+- Le format d'export est rétrocompatible pour tous les opcodes autres qu'ONGOTO — les scripts déjà traduits d'autres jeux (AIR, Kanon, LB_EN…) ne sont pas affectés.
+- Les anciens dumps CartagraHD contenant des ONGOTO en entiers bruts **doivent être ré-extraits** avec le plugin corrigé avant tout réimport.
+
+---
+
+# V3.1.8 — Dedicated Vietnamese font GUI patcher + Latin redraw test mode
+
+## Fichiers modifiés
+
+### CLI / core
+- `cmd/root.go` — bump de version CLI vers `2.3.2-yoremi.3.1.8`.
+
+### GUI
+- `SourcesGUI-wails/vietnamese_font.go` — workflow AIR / Planetarian SG intégré dans la GUI, avec mode sûr et mode expérimental de redraw latin.
+- `SourcesGUI-wails/frontend/src/App.svelte` — ajout de la case `Experimental: redraw Latin alphabet from TTF`, passage du nouveau paramètre au backend et libellés `v3.1.8`.
+- `SourcesGUI-wails/frontend/wailsjs/go/main/App.js`
+- `SourcesGUI-wails/frontend/wailsjs/go/main/App.d.ts`
+- `SourcesGUI-wails/main.go`
+- `SourcesGUI-wails/frontend/package.json`
+- `SourcesGUI-wails/frontend/package-lock.json`
+- `SourcesGUI-wails/frontend/package.json.md5`
+- `SourcesGUI-wails/GUI-Windows-README.md`
+- `SourcesGUI-wails/GUI-Linux-README.md`
+
+### Documentation
+- `README.md`
+- `Fork-CHANGELOG.md`
+- `Fork-TECHNICAL.md`
+
+## Contexte
+
+Le patch v3.1.7 injectait uniquement les caractères vietnamiens absents et conservait volontairement les glyphes déjà présents dans le jeu. C'était le choix le plus sûr pour éviter les régressions de menu.
+
+Le retour du testeur vietnamien soulève un vrai problème visuel : une phrase vietnamienne peut mélanger des glyphes latins originaux du jeu avec des glyphes vietnamiens nouvellement dessinés depuis la TTF. Si les deux fontes n'ont pas exactement la même baseline ou le même style, un léger désalignement peut rester perceptible.
+
+## Détail du nouveau mode
+
+La GUI propose maintenant une case expérimentale :
+
+```text
+Experimental: redraw Latin alphabet from TTF
+```
+
+Mode désactivé :
+
+- comportement sûr existant;
+- les glyphes déjà présents restent dans leurs cellules originales;
+- seuls les caractères vietnamiens manquants sont injectés dans les cellules de fin.
+
+Mode activé :
+
+- les caractères `A-Z` et `a-z` déjà mappés sont redessinés dans leurs cellules originales avec la TTF sélectionnée;
+- les caractères vietnamiens du charset demandé qui existaient déjà dans le jeu sont aussi redessinés en place;
+- les caractères vietnamiens manquants sont toujours injectés dans les cellules de fin;
+- les mappings Unicode ne changent pas pour les lettres latines existantes.
+
+## Pourquoi ne pas append un deuxième alphabet latin ?
+
+Ajouter un second `A-Z/a-z` en fin de charset ne garantit pas que le moteur l'utilise. Comme les lettres latines existent déjà dans la table, le moteur continuera très probablement à lire les index originaux.
+
+Le mode expérimental redessine donc les cellules existantes au lieu d'ajouter des doublons. Cela teste l'hypothèse du testeur sans modifier la logique de mapping du moteur.
+
+## Sorties générées
+
+Les sorties expérimentales ajoutent `_LATIN` au nom du dossier :
+
+```text
+FontName_en_GOTHIC1_Y+2
+FontName_en_GOTHIC1_LATIN_Y+2
+```
+
+Cela permet de comparer le mode sûr et le mode expérimental sans écraser les PAK.
+
+## Tests réalisés
+
+- `go test ./... -run '^$'`
+- `go test ./... -run '^$'` depuis `SourcesGUI-wails`
+- `npm run build` depuis `SourcesGUI-wails/frontend`
+- `wails build` depuis `SourcesGUI-wails`
+
+---
+
 # V3.1.7 — AIR Vietnamese font rebuild / compact PAK fix
 
 ## Fichiers modifiés

--- a/GUI/data/base/cartagrahd.py
+++ b/GUI/data/base/cartagrahd.py
@@ -19,6 +19,15 @@ def GOTO():
     core.read_jump()
     core.end()
 
+def ONGOTO():
+    # ONGOTO (int, expr_str, [{int, jump}...])
+    core.read_uint16(True)
+    core.read_str(core.expr)
+    while core.can_read():
+        core.read_uint16(False)
+        core.read_jump()
+    core.end()
+
 def JUMP():
     # JUMP (int, file_str, {jump})
     core.read_uint16(True)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# LuckSystem 2.3.2 — Yoremi Fork (v3.1.6)
+# LuckSystem 2.3.2 — Yoremi Fork (v3.1.7)
 
 Fork de [LuckSystem](https://github.com/wetor/LuckSystem) avec corrections de bugs, support de nouveaux formats, et interface graphique pour la traduction de visual novels Visual Art's/Key.
 
@@ -42,7 +42,23 @@ A Linux version is available as separate binaries (GUI + CLI). See the releases 
 
 ## Patches
 
-### Version 3.1.5 — Patch 1 *(latest)*
+### Version 3.1.7 — *(latest)*
+
+24. **AIR Vietnamese font workflow fix** — `font/info.go`, `font/font.go`, `czimage/cz2.go`, `czimage/util.go`, `pak/pak.go`, `tools/fontdiag`, `tools/vietfontpatch`
+    - Preserves AIR's legacy `CharNum=100 + CharNum2` font-info layout when writing edited font tables.
+    - Keeps original CZ2 atlas dimensions during partial charset replacement and preserves original CZ2 raw block boundaries whenever possible.
+    - Forces compact PAK rebuilds for rewritten font families and truncates rebuilt PAKs to the aligned real end, avoiding internal gaps and stale copied tails that caused AIR startup failures.
+    - Adds diagnostic and Vietnamese font patch helper tools; `vietfontpatch` can patch only selected slots/families (`-slot en`, `-family GOTHIC1`) and adjust injected glyph vertical metrics (`-yoffset`, AIR English slot validated with `Y+2`).
+    - Keeps already-present Vietnamese characters mapped to their original glyphs and injects only missing characters, preventing regressions on existing accented glyphs.
+    - Minor Go vet cleanup in `game/runtime/global_goto.go`.
+    - GUI source version labels updated to `v3.1.7` and stale duplicate frontend Go file removed; no GUI workflow regression expected because the GUI still calls the CLI as a subprocess.
+
+### Version 3.1.6
+Patch 1 : Bug fixed: `Cz2Image.decompress` panics with `index out of range` on round-trip and silently corrupts pixels on load
+
+Patch 2 : silent 18-bit truncation in `compressLZW2`
+
+### Version 3.1.5 — Patch 1
 
 22. **Improved error reporting for script import + silent raw-byte log removal** — `script/script.go`, `game/VM/vm.go`, `game/operator/opcode.go`
     - `Import()`: error messages now include script name and line number; detects extra lines in translated files and reports: `[seen110] file has 1 extra line(s) beyond expected 3206 (check for stray newlines)`
@@ -156,9 +172,10 @@ A Linux version is available as separate binaries (GUI + CLI). See the releases 
 
 | Document | Description |
 |----------|-------------|
-| [CHANGELOG.md](CHANGELOG.md) | Full changelog — all versions (EN + FR) |
-| [TECHNICAL.md](TECHNICAL.md) | Technical analysis — all patches |
-| [Usage.md](Usage.md) | CLI command reference |
+| [Fork-CHANGELOG.md](Fork-CHANGELOG.md) | Full changelog — all versions (EN + FR) |
+| [Fork-TECHNICAL.md](Fork-TECHNICAL.md) | Technical analysis — all patches |
+| [AIR_VIETNAMESE_FONT_GUI_GUIDE.md](AIR_VIETNAMESE_FONT_GUI_GUIDE.md) | Practical GUI procedure for AIR Vietnamese font tests |
+| `LuckSystem --help` | CLI command reference |
 
 ---
 
@@ -185,7 +202,7 @@ lucksystem font edit -s 明朝32 -S info32 -f Arial.ttf -o 明朝32_out -O info3
 
 ## Tested games / Jeux testés
 
-- **AIR** (Steam) — French translation complete (scripts + CG + UI)
+- **AIR** (Steam) — French translation complete (scripts + CG + UI); Vietnamese font injection validated on English slot with `FONT_GOTHIC1` / `Y+2`
 - **Summer Pockets** — RawSize fix confirmed
 - **Kanon** (Steam) — CZ2 font fix confirmed; script decompile confirmed (plugin import fix v3.1.4)
 - **Little Busters English** — CZ4 confirmed, script decompile confirmed (161 scripts, 102k+ MESSAGE lines, text properly decoded)
@@ -197,7 +214,7 @@ lucksystem font edit -s 明朝32 -S info32 -f Arial.ttf -o 明朝32_out -O info3
 - **[wetor](https://github.com/wetor)** — LuckSystem original
 - **masagrator** — RawSize bug identification (CZ3 layers)
 - **[G2-Games](https://github.com/G2-Games)** — CZ4 reference ([lbee-utils](https://github.com/G2-Games/lbee-utils))
-- **Yoremi** — patches 1-21, AIR French translation, GUI
+- **Yoremi** — patches 1-24, AIR French translation, GUI
 --------------------
 # Important
 This project only accepts **bug issues** and **pull requests**, and does not provide assistance in use  
@@ -207,8 +224,8 @@ This project only accepts **bug issues** and **pull requests**, and does not pro
 
 LucaSystem 引擎解析工具
 
-## 使用方法：[Usage](Usage.md)
-## 插件手册：[Plugin](Plugin.md)
+## 使用方法：运行 `LuckSystem --help`
+## 插件：参考 `data/*.py` 与 `data/base/*.py`
 
 ## LucaSystem解析完成进度
 
@@ -255,7 +272,7 @@ LucaSystem 引擎解析工具
 - ~~简单的模拟执行~~
 - 支持插件扩展（gpython）
   - 非标准的Python，语法类似Python3.4，缺少大量的内置库和一些特性，基本使用没有问题
-  - 插件手册 [Plugin](Plugin.md)
+  - 插件示例：`data/*.py` 与 `data/base/*.py`
 
 #### 笔记
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# LuckSystem 2.3.2 — Yoremi Fork (v3.1.7)
+# LuckSystem 2.3.2 — Yoremi Fork (v3.1.9)
 
 Fork de [LuckSystem](https://github.com/wetor/LuckSystem) avec corrections de bugs, support de nouveaux formats, et interface graphique pour la traduction de visual novels Visual Art's/Key.
 
@@ -14,8 +14,8 @@ ProtoDB / LUCA System — AIR, CLANNAD, Kanon, Little Busters, Summer Pockets, H
 
 ## GUI
 
-A graphical interface is available in a separate repository:
-**[LuckSystem-2.3.2-Yoremi-Update + GUI](https://github.com/yoremi-trad-fr/LuckSystem-2.3.2-Yoremi-Update)** — Built with Wails (Go + Svelte), calls `lucksystem.exe` via subprocess.
+A graphical interface is available in this fork:
+**[LuckSystem-2.3.2-Yoremi-Update + GUI](https://github.com/yoremi-trad-fr/LuckSystem-2.3.2-Yoremi-Update)** — Built with Wails (Go + Svelte). Most workflows call `lucksystem.exe` via subprocess; the AIR / Planetarian SG Vietnamese font patcher is embedded directly in the GUI.
 
 ### GUI Features
 - **Game presets** / Auto-detect available games from data/ folder (OPCODE + plugin auto-fill)
@@ -24,6 +24,7 @@ A graphical interface is available in a separate repository:
 - Script Decompile / Compile
 - PAK Extract / Replace (CG and Font workflows separated)
 - Font Extract / Edit (append, insert, redraw modes)
+- Vietnamese Font Patch for AIR / Planetarian SG (slot/family selectors, TTF/OTF selection, Y-offset test folders, optional Latin redraw test mode)
 - Image Export / Import (single file + batch folder mode)
 - Real-time console output
 - **Stop button** to cancel any running operation
@@ -42,13 +43,32 @@ A Linux version is available as separate binaries (GUI + CLI). See the releases 
 
 ## Patches
 
-### Version 3.1.7 — *(latest)*
+### Version 3.1.9 — *(latest)*
+
+26. **CartagraHD ONGOTO fix + multi-goto support + zero-length string dump fix** — `data/base/cartagrahd.py`, `script/model.go`, `script/script.go`, `game/operator/util.go`
+    - `cartagrahd.py`: added `ONGOTO` handler that reads N branch targets and emits them as `{goto label_NNNN}` references instead of falling through to `UNDEFINED()` with raw uint16 dumps.
+    - `script/model.go`: extended `JumpParam` to hold a slice of targets per line, enabling a single script line to carry N `{goto ...}` tokens.
+    - `script/script.go`: updated `Export()` and `Import()` to iterate over all targets on a line; `Import()` recalculates each branch offset independently so all N ONGOTO branches are correctly repointed after line-size changes.
+    - `game/operator/util.go`: fixed zero-length string edge case — a zero-length entry no longer emits a spurious character before the closing delimiter.
+    - Existing CartagraHD dumps containing raw ONGOTO integers must be re-extracted with the corrected plugin before reimport.
+
+### Version 3.1.8
+
+25. **Dedicated AIR / Planetarian SG Vietnamese font GUI patcher + Latin redraw test mode** — `SourcesGUI-wails/vietnamese_font.go`, `SourcesGUI-wails/frontend/src/App.svelte`, `SourcesGUI-wails/frontend/wailsjs/go/main/App.js`, `SourcesGUI-wails/frontend/wailsjs/go/main/App.d.ts`
+    - Adds `VIET FONT -> AIR / SG Patch`, a beginner-safe GUI workflow for generating Vietnamese font PAKs from the original game `files` folder.
+    - Embeds the corrected Vietnamese font patch logic directly in the GUI so users do not need separate `vietnamesefont.exe` / `vietfontpatch.exe` helpers.
+    - Supports slot selection (`English`, `Chinese`, `All`), family selection (`GOTHIC1` quick test or all families), TTF/OTF selection, and Y-offset checkboxes from `Y-2` to `Y+3`.
+    - Adds an experimental checkbox: `Redraw Latin alphabet from TTF`. This redraws existing `A-Z/a-z` cells and already-present Vietnamese glyphs from the selected TTF while still injecting only missing Vietnamese glyphs into the tail cells.
+    - Generates a separate output folder for the experimental mode with `_LATIN` in the folder name, so safe and Latin-redraw tests cannot overwrite each other.
+    - GUI and CLI version labels updated to `v3.1.8`.
+
+### Version 3.1.7
 
 24. **AIR Vietnamese font workflow fix** — `font/info.go`, `font/font.go`, `czimage/cz2.go`, `czimage/util.go`, `pak/pak.go`, `tools/fontdiag`, `tools/vietfontpatch`
     - Preserves AIR's legacy `CharNum=100 + CharNum2` font-info layout when writing edited font tables.
     - Keeps original CZ2 atlas dimensions during partial charset replacement and preserves original CZ2 raw block boundaries whenever possible.
     - Forces compact PAK rebuilds for rewritten font families and truncates rebuilt PAKs to the aligned real end, avoiding internal gaps and stale copied tails that caused AIR startup failures.
-     - (Not included here, only on my repository)-Adds diagnostic and Vietnamese font patch helper tools; `vietfontpatch` can patch only selected slots/families (`-slot en`, `-family GOTHIC1`) and adjust injected glyph vertical metrics (`-yoffset`, AIR English slot validated with `Y+2`).
+    - Adds diagnostic and Vietnamese font patch helper tools; `vietfontpatch` can patch only selected slots/families (`-slot en`, `-family GOTHIC1`) and adjust injected glyph vertical metrics (`-yoffset`, AIR English slot validated with `Y+2`).
     - Keeps already-present Vietnamese characters mapped to their original glyphs and injects only missing characters, preventing regressions on existing accented glyphs.
     - Minor Go vet cleanup in `game/runtime/global_goto.go`.
     - GUI source version labels updated to `v3.1.7` and stale duplicate frontend Go file removed; no GUI workflow regression expected because the GUI still calls the CLI as a subprocess.
@@ -175,6 +195,8 @@ Patch 2 : silent 18-bit truncation in `compressLZW2`
 | [Fork-CHANGELOG.md](Fork-CHANGELOG.md) | Full changelog — all versions (EN + FR) |
 | [Fork-TECHNICAL.md](Fork-TECHNICAL.md) | Technical analysis — all patches |
 | [AIR_VIETNAMESE_FONT_GUI_GUIDE.md](AIR_VIETNAMESE_FONT_GUI_GUIDE.md) | Practical GUI procedure for AIR Vietnamese font tests |
+| [AIR_VIETNAMESE_FONT_WINDOWS_TECHNICAL_GUIDE.md](AIR_VIETNAMESE_FONT_WINDOWS_TECHNICAL_GUIDE.md) | Windows technical procedure for TTF/Y-offset tests and tool builds |
+| [VIETNAMESE_FONT_PATCH_GUI_BEGINNER_GUIDE.md](VIETNAMESE_FONT_PATCH_GUI_BEGINNER_GUIDE.md) | Beginner guide for the dedicated Vietnamese font GUI patcher |
 | `LuckSystem --help` | CLI command reference |
 
 ---
@@ -202,7 +224,7 @@ lucksystem font edit -s 明朝32 -S info32 -f Arial.ttf -o 明朝32_out -O info3
 
 ## Tested games / Jeux testés
 
-- **AIR** (Steam) — French translation complete (scripts + CG + UI); Vietnamese font injection validated on English slot with `FONT_GOTHIC1` / `Y+2`
+- **AIR** (Steam) — French translation complete (scripts + CG + UI); Vietnamese font injection validated on English slot with `FONT_GOTHIC1` / `Y+2`; optional Latin-redraw test mode available in the dedicated GUI patcher
 - **Summer Pockets** — RawSize fix confirmed
 - **Kanon** (Steam) — CZ2 font fix confirmed; script decompile confirmed (plugin import fix v3.1.4)
 - **Little Busters English** — CZ4 confirmed, script decompile confirmed (161 scripts, 102k+ MESSAGE lines, text properly decoded)
@@ -214,7 +236,7 @@ lucksystem font edit -s 明朝32 -S info32 -f Arial.ttf -o 明朝32_out -O info3
 - **[wetor](https://github.com/wetor)** — LuckSystem original
 - **masagrator** — RawSize bug identification (CZ3 layers)
 - **[G2-Games](https://github.com/G2-Games)** — CZ4 reference ([lbee-utils](https://github.com/G2-Games/lbee-utils))
-- **Yoremi** — patches 1-24, AIR French translation, GUI
+- **Yoremi** — patches 1-25, AIR French translation, GUI
 --------------------
 # Important
 This project only accepts **bug issues** and **pull requests**, and does not provide assistance in use  

--- a/data/base/cartagrahd.py
+++ b/data/base/cartagrahd.py
@@ -1,6 +1,5 @@
 import core
 
-
 def IFN():
     # IFN (int, expr_str, {jump})
     core.read_uint16(True)
@@ -20,19 +19,19 @@ def GOTO():
     core.read_jump()
     core.end()
 
+def ONGOTO():
+    # ONGOTO (int, expr_str, [{int, jump}...])
+    core.read_uint16(True)
+    core.read_str(core.expr)
+    while core.can_read():
+        core.read_uint16(False)
+        core.read_jump()
+    core.end()
+
 def JUMP():
     # JUMP (int, file_str, {jump})
     core.read_uint16(True)
     file = core.read_str(core.expr)
     if core.can_read():
         core.read_jump(file)
-    core.end()
-
-
-def ONGOTO():
-    # ONGOTO (expr, [<const_num>, label1, <const_num>, label2, ...])
-    core.read_len_str(core.Charset_UTF8)
-    while core.can_read():
-        core.read_uint16(False)
-        core.read_jump()
     core.end()

--- a/font/font.go
+++ b/font/font.go
@@ -24,12 +24,12 @@ type LucaFont struct {
 }
 
 // LoadLucaFontPak 通过pak加载LucaFont
-//  Description
-//  Param pak *pak.PakFile
-//  Param fontName string モダン/明朝/丸ゴシック/ゴシック
-//  Param size int 12 14 16 18 20 24 28 30 32 36 72
-//  Return *LucaFont
 //
+//	Description
+//	Param pak *pak.PakFile
+//	Param fontName string モダン/明朝/丸ゴシック/ゴシック
+//	Param size int 12 14 16 18 20 24 28 30 32 36 72
+//	Return *LucaFont
 func LoadLucaFontPak(pak *pak.Pak, fontName string, size int) *LucaFont {
 	infoFile, err := pak.Get("info" + strconv.Itoa(size))
 	if err != nil {
@@ -43,11 +43,11 @@ func LoadLucaFontPak(pak *pak.Pak, fontName string, size int) *LucaFont {
 }
 
 // LoadLucaFontFile 通过文件名加载LucaFont
-//  Description
-//  Param infoFilename string
-//  Param imageFilename string
-//  Return *LucaFont
 //
+//	Description
+//	Param infoFilename string
+//	Param imageFilename string
+//	Return *LucaFont
 func LoadLucaFontFile(infoFilename, imageFilename string) *LucaFont {
 	infoFile, err := os.ReadFile(infoFilename)
 	if err != nil {
@@ -61,11 +61,11 @@ func LoadLucaFontFile(infoFilename, imageFilename string) *LucaFont {
 }
 
 // LoadLucaFont 通过字节数据加载LucaFont
-//  Description
-//  Param infoFile []byte
-//  Param imageFile []byte
-//  Return *LucaFont
 //
+//	Description
+//	Param infoFile []byte
+//	Param imageFile []byte
+//	Return *LucaFont
 func LoadLucaFont(infoFile, imageFile []byte) *LucaFont {
 	font := &LucaFont{}
 	font.Info = LoadFontInfo(infoFile)
@@ -77,12 +77,12 @@ func LoadLucaFont(infoFile, imageFile []byte) *LucaFont {
 }
 
 // GetCharImage 获取单个字符图像和偏移信息
-//  Description
-//  Receiver f *LucaFont
-//  Param unicode rune
-//  Return image.Image
-//  Return DrawSize
 //
+//	Description
+//	Receiver f *LucaFont
+//	Param unicode rune
+//	Return image.Image
+//	Return DrawSize
 func (f *LucaFont) GetCharImage(unicode rune) (image.Image, DrawSize) {
 
 	index, draw, _ := f.Info.Get(unicode)
@@ -93,12 +93,12 @@ func (f *LucaFont) GetCharImage(unicode rune) (image.Image, DrawSize) {
 }
 
 // GetStringImageList 获取字符串每个字符的图像和偏移信息
-//  Description
-//  Receiver f *LucaFont
-//  Param str string
-//  Return []image.Image
-//  Return []DrawSize
 //
+//	Description
+//	Receiver f *LucaFont
+//	Param str string
+//	Return []image.Image
+//	Return []DrawSize
 func (f *LucaFont) GetStringImageList(str string) ([]image.Image, []DrawSize) {
 	imgs := make([]image.Image, 0, len(str))
 	draws := make([]DrawSize, 0, len(str))
@@ -111,11 +111,11 @@ func (f *LucaFont) GetStringImageList(str string) ([]image.Image, []DrawSize) {
 }
 
 // GetStringImage 将字符串转化为图像
-//  Description
-//  Receiver f *LucaFont
-//  Param str string
-//  Return image.Image
 //
+//	Description
+//	Receiver f *LucaFont
+//	Param str string
+//	Return image.Image
 func (f *LucaFont) GetStringImage(str string) image.Image {
 	imgW := int(f.Info.BlockSize)
 	imgs, draws := f.GetStringImageList(str)
@@ -131,12 +131,12 @@ func (f *LucaFont) GetStringImage(str string) image.Image {
 }
 
 // CreateLucaFont 创建全新的字体
-//  Description
-//  Param fontSize int 字体大小
-//  Param fontFile io.Reader 字体文件
-//  Param allChar string 所有字符
-//  Return *LucaFont
 //
+//	Description
+//	Param fontSize int 字体大小
+//	Param fontFile io.Reader 字体文件
+//	Param allChar string 所有字符
+//	Return *LucaFont
 func CreateLucaFont(fontSize int, fontFile io.Reader, allChar string) *LucaFont {
 	font := &LucaFont{
 		Size: fontSize,
@@ -149,13 +149,13 @@ func CreateLucaFont(fontSize int, fontFile io.Reader, allChar string) *LucaFont 
 }
 
 // ReplaceChars 替换字体中的字符
-//  Description 替换字体中的字符信息以及图像, 如果startIndex=0且allChar为空，则为修改原字体
-//  Receiver f *LucaFont
-//  Param fontFile io.Reader 字体文件
-//  Param allChar string 所替换的字符
-//  Param startIndex int 开始序号（图像从上到下，从左到右计算）
-//  Param reDraw bool 是否用新字体重绘startIndex之前的字符
 //
+//	Description 替换字体中的字符信息以及图像, 如果startIndex=0且allChar为空，则为修改原字体
+//	Receiver f *LucaFont
+//	Param fontFile io.Reader 字体文件
+//	Param allChar string 所替换的字符
+//	Param startIndex int 开始序号（图像从上到下，从左到右计算）
+//	Param reDraw bool 是否用新字体重绘startIndex之前的字符
 func (f *LucaFont) ReplaceChars(fontFile io.Reader, allChar string, startIndex int, reDraw bool) {
 
 	if f.Info == nil {
@@ -170,12 +170,21 @@ func (f *LucaFont) ReplaceChars(fontFile io.Reader, allChar string, startIndex i
 	size := int(f.Info.BlockSize)
 	imageW := size*100 + 4                                         // 100个字符宽度+4
 	imageH := size * int(math.Ceil(float64(f.Info.CharNum)/100.0)) // 对应行数高度
-	oldImageH := size * int(math.Ceil(float64(startIndex)/100.0))
+	if f.Image != nil {
+		oldSize := f.Image.Bounds().Size()
+		if oldSize.X > imageW {
+			imageW = oldSize.X
+		}
+		if oldSize.Y > imageH {
+			imageH = oldSize.Y
+		}
+	}
 
 	pic := image.NewNRGBA(image.Rect(0, 0, imageW, imageH))
 	if !reDraw && f.Image != nil {
-		img := f.Image.SubImage(image.Rect(0, 0, imageW, oldImageH))
-		draw.Draw(pic, pic.Bounds().Add(image.Pt(0, 0)), img, img.Bounds().Min, draw.Src)
+		oldBounds := f.Image.Bounds()
+		copyRect := image.Rect(0, 0, oldBounds.Dx(), oldBounds.Dy()).Intersect(pic.Bounds())
+		draw.Draw(pic, copyRect, f.Image, oldBounds.Min, draw.Src)
 	}
 
 	alphaMask := image.NewAlpha(image.Rect(0, 0, size, size))
@@ -192,21 +201,19 @@ func (f *LucaFont) ReplaceChars(fontFile io.Reader, allChar string, startIndex i
 		_, img, _, _, _ := f.Info.FontFace.Glyph(point, f.Info.IndexUnicode[i])
 		// yOffset := dr.Min.Y + fontSize
 		// fmt.Println(string(font.Info.IndexFont[i]), " ", dr.Min.Y+fontSize)
-		if y == startIndex/100 {
-			draw.Draw(pic, pic.Bounds().Add(image.Pt(x*size, y*size)), alphaMask, alphaMask.Bounds().Min, draw.Src)
-		}
+		draw.Draw(pic, pic.Bounds().Add(image.Pt(x*size, y*size)), alphaMask, alphaMask.Bounds().Min, draw.Src)
 		draw.Draw(pic, pic.Bounds().Add(image.Pt(x*size, y*size)), img, img.Bounds().Min, draw.Src)
 	}
 	f.Image = pic
 }
 
 // Export
-//  Description
-//  Receiver f *LucaFont
-//  Param w io.Writer
-//  Param allCharFile string 导出的全字符文件名
-//  Return error
 //
+//	Description
+//	Receiver f *LucaFont
+//	Param w io.Writer
+//	Param allCharFile string 导出的全字符文件名
+//	Return error
 func (f *LucaFont) Export(w io.Writer, allCharFile string) error {
 	err := png.Encode(w, f.Image)
 	if err != nil {
@@ -221,14 +228,14 @@ func (f *LucaFont) Export(w io.Writer, allCharFile string) error {
 }
 
 // Import
-//  Description 若startIndex=0, redraw=true, allChar="", 则仅使用字体重绘原字符集
-//  Receiver f *LucaFont
-//  Param r io.Reader 字体文件
-//  Param startIndex int 开始位置。前面跳过字符数量，-1为添加到最后
-//  Param redraw bool 是否用新字体重绘startIndex之前的字符
-//  Param allChar string 增加的全字符，若startIndex==0，且第一个字符不是空格，会自动补充为空格
-//  Return error
 //
+//	Description 若startIndex=0, redraw=true, allChar="", 则仅使用字体重绘原字符集
+//	Receiver f *LucaFont
+//	Param r io.Reader 字体文件
+//	Param startIndex int 开始位置。前面跳过字符数量，-1为添加到最后
+//	Param redraw bool 是否用新字体重绘startIndex之前的字符
+//	Param allChar string 增加的全字符，若startIndex==0，且第一个字符不是空格，会自动补充为空格
+//	Return error
 func (f *LucaFont) Import(r io.Reader, startIndex int, redraw bool, allCharFile string) error {
 
 	if len(allCharFile) == 0 {
@@ -250,12 +257,12 @@ func (f *LucaFont) Import(r io.Reader, startIndex int, redraw bool, allCharFile 
 }
 
 // Write
-//  Description
-//  Receiver f *LucaFont
-//  Param w io.Writer
-//  Param infoW io.Writer 导出新的info文件
-//  Return error
 //
+//	Description
+//	Receiver f *LucaFont
+//	Param w io.Writer
+//	Param infoW io.Writer 导出新的info文件
+//	Return error
 func (f *LucaFont) Write(w io.Writer, infoW io.Writer) error {
 	var err error
 	if f.CzImage != nil {
@@ -267,6 +274,16 @@ func (f *LucaFont) Write(w io.Writer, infoW io.Writer) error {
 			return err
 		}
 		czImg := bytes.NewBuffer(nil)
+		// Yoremi Patch 3: sync CzHeader dimensions with the (possibly resized) image
+		// before calling Import, so CZ2.Import sees the correct target dimensions.
+		if setter, ok := f.CzImage.(interface {
+			SetDimensions(w, h uint16)
+		}); ok {
+			setter.SetDimensions(
+				uint16(f.Image.Bounds().Size().X),
+				uint16(f.Image.Bounds().Size().Y),
+			)
+		}
 		err = f.CzImage.Import(img, true)
 		if err != nil {
 			return err

--- a/font/info.go
+++ b/font/info.go
@@ -31,6 +31,7 @@ type Info struct {
 	// FontMap     map[rune]uint16 `struct:"-"` // unicode -> imgindex
 	FontFace     font.Face `struct:"-"`
 	IndexUnicode []rune    `struct:"-"` // imgindex -> unicode
+	UseCharNum2  bool      `struct:"-"` // preserve legacy CharNum=100 + CharNum2 layout
 }
 
 func LoadFontInfoFile(file string) *Info {
@@ -47,6 +48,7 @@ func LoadFontInfo(data []byte) *Info {
 		glog.Fatalln("restruct.Unpack", err)
 	}
 	if info.CharNum == 100 {
+		info.UseCharNum2 = true
 		info.CharNum = info.CharNum2
 		info.CharNum2 = 100
 	}
@@ -89,11 +91,11 @@ func (i *Info) Get(unicode rune) (int, DrawSize, CharSize) {
 }
 
 // CreateFontInfo 创建字体Info信息
-//  Description
-//  Param fontSize int 字体实际大小
-//  Param blockSize int 字体所在区域大小（超过会被切割）
-//  Return *FontInfo
 //
+//	Description
+//	Param fontSize int 字体实际大小
+//	Param blockSize int 字体所在区域大小（超过会被切割）
+//	Return *FontInfo
 func CreateFontInfo(fontSize, blockSize int) *Info {
 
 	info := &Info{
@@ -108,13 +110,13 @@ func CreateFontInfo(fontSize, blockSize int) *Info {
 }
 
 // SetChars
-//  Description 如果startIndex=0且allChar为空，则为仅重绘
-//  Receiver i *Info
-//  Param fontFile io.Reader 字体文件
-//  Param allChar string 全字符串，若第一个字符不是空格，会自动补充为空格
-//  Param startIndex int 开始位置，即字库上面跳过多少字符
-//  Param reDraw bool 是否用新字体重绘startIndex之前的字符
 //
+//	Description 如果startIndex=0且allChar为空，则为仅重绘
+//	Receiver i *Info
+//	Param fontFile io.Reader 字体文件
+//	Param allChar string 全字符串，若第一个字符不是空格，会自动补充为空格
+//	Param startIndex int 开始位置，即字库上面跳过多少字符
+//	Param reDraw bool 是否用新字体重绘startIndex之前的字符
 func (i *Info) SetChars(fontFile io.Reader, allChar string, startIndex int, reDraw bool) {
 
 	if len(allChar) == 0 && startIndex == 0 && !reDraw {
@@ -225,25 +227,25 @@ func (i *Info) SetChars(fontFile io.Reader, allChar string, startIndex int, reDr
 }
 
 // Import
-//  Description 若startIndex=0, redraw=true, allChar="", 则仅使用字体重绘原字符集
-//  Receiver i *Info
-//  Param r io.Reader 字体文件
-//  Param startIndex int 开始位置。前面跳过字符数量
-//  Param redraw bool 是否用新字体重绘startIndex之前的字符
-//  Param allChar string 增加的全字符，若startIndex==0，且第一个字符不是空格，会自动补充为空格
-//  Return error
 //
+//	Description 若startIndex=0, redraw=true, allChar="", 则仅使用字体重绘原字符集
+//	Receiver i *Info
+//	Param r io.Reader 字体文件
+//	Param startIndex int 开始位置。前面跳过字符数量
+//	Param redraw bool 是否用新字体重绘startIndex之前的字符
+//	Param allChar string 增加的全字符，若startIndex==0，且第一个字符不是空格，会自动补充为空格
+//	Return error
 func (i *Info) Import(r io.Reader, startIndex int, redraw bool, allChar string) error {
 	i.SetChars(r, allChar, startIndex, redraw)
 	return nil
 }
 
 // Export
-//  Description
-//  Receiver i *Info
-//  Param w io.Writer
-//  Return error
 //
+//	Description
+//	Receiver i *Info
+//	Param w io.Writer
+//	Return error
 func (i *Info) Export(w io.Writer) error {
 
 	var err error
@@ -262,14 +264,19 @@ func (i *Info) Export(w io.Writer) error {
 }
 
 // Write
-//  Description
-//  Receiver i *Info
-//  Param w io.Writer
-//  Return error
 //
+//	Description
+//	Receiver i *Info
+//	Param w io.Writer
+//	Return error
 func (i *Info) Write(w io.Writer) error {
 
-	data, err := restruct.Pack(binary.LittleEndian, i)
+	out := *i
+	if i.UseCharNum2 && i.CharNum != 100 {
+		out.CharNum2 = i.CharNum
+		out.CharNum = 100
+	}
+	data, err := restruct.Pack(binary.LittleEndian, &out)
 	if err != nil {
 		glog.Fatalln("restruct.Pack", err)
 	}

--- a/game/operator/util.go
+++ b/game/operator/util.go
@@ -145,14 +145,15 @@ func GetParam(codeBytes []byte, data ...interface{}) int {
 		return next
 	case *lstring:
 		l := int(ToUint16(codeBytes[start : start+2]))
+		if l == 0 {
+			*value = lstring("")
+			return start + 2
+		}
 		switch coding {
 		case charset.Unicode, charset.ShiftJIS:
 			size = l * 2
 		case charset.UTF_8:
 			size = 0x10000 - l
-		}
-		if l == 0 {
-			size = 0
 		}
 		tmp, next := DecodeString(codeBytes, start+2, size, coding)
 		*value = lstring(tmp)

--- a/script/model.go
+++ b/script/model.go
@@ -12,9 +12,10 @@ type GlobalLabel struct {
 }
 
 type JumpParam struct {
-	LabelIndex int
-	ScriptName string
-	Position   int
+	GlobalIndex int
+	LabelIndex  int
+	ScriptName  string
+	Position    int
 }
 
 type StringParam struct {

--- a/script/script.go
+++ b/script/script.go
@@ -155,10 +155,10 @@ func (s *Script) SetOperateParams(index int, mode enum.VMRunMode, params ...inte
 					paramList = append(paramList, val)
 				}
 			case *JumpParam:
-				paramList = append(paramList, param)
 				if param.GlobalIndex == 0 {
-					s.AddExportGotoLabel(index, param.Position)
+					param.LabelIndex = s.AddExportGotoLabel(index, param.Position)
 				}
+				paramList = append(paramList, param)
 			case *StringParam:
 				paramList = append(paramList, param.Data)
 			default:
@@ -239,6 +239,18 @@ func (s *Script) SetOperateParams(index int, mode enum.VMRunMode, params ...inte
 					}
 					// Toujours ajouter le StringParam même si pi dépasse
 					allParamList = append(allParamList, param)
+					pi++
+				case *JumpParam:
+					if pi >= len(code.Params) {
+						return fmt.Errorf("[%s] line %d (%s): missing goto parameter %d",
+							s.Name, index+1, code.OpStr, pi)
+					}
+					jump, ok := code.Params[pi].(*JumpParam)
+					if !ok {
+						return fmt.Errorf("[%s] line %d (%s): parameter %d type mismatch: expected goto label, got %T (re-decompile this script with the updated plugin)",
+							s.Name, index+1, code.OpStr, pi, code.Params[pi])
+					}
+					allParamList = append(allParamList, jump)
 					pi++
 				default:
 					if pi < len(code.Params) {
@@ -396,16 +408,30 @@ func (s *Script) ReadData(data []byte) error {
 func (s *Script) CodeParamsToBytes(code *CodeLine, coding charset.Charset, params []interface{}) {
 	buf := &bytes.Buffer{}
 	size := 0
-	position := 0
+	lastJumpPos := 0
+	paramJumpRegistered := false
 	for _, param := range code.FixedParam {
 		l, _ := SetParam(buf, param, coding, false)
 		size += l
 	}
 	for _, param := range params {
+		paramPos := size
 		l, j := SetParam(buf, param, coding, false)
 		size += l
 		if j {
-			position = size - 4
+			lastJumpPos = s.CurPos + 4 + paramPos
+			if jump, ok := param.(*JumpParam); ok {
+				labelIndex := jump.LabelIndex
+				if labelIndex == 0 {
+					labelIndex = jump.Position
+				}
+				if jump.GlobalIndex > 0 {
+					s.AddImportGlobalGoto(lastJumpPos, jump.GlobalIndex)
+				} else {
+					s.AddImportGoto(lastJumpPos, labelIndex)
+				}
+				paramJumpRegistered = true
+			}
 		}
 
 	}
@@ -413,20 +439,19 @@ func (s *Script) CodeParamsToBytes(code *CodeLine, coding charset.Charset, param
 		glog.V(8).Infof("%s: size %d -> %d\n", code.OpStr, len(code.RawBytes), buf.Len())
 	}
 	code.Len = uint16(size + 4)
-	position += 4
 	code.Align = make([]byte, code.Len&1)
 	code.RawBytes = buf.Bytes()
 	if code.LabelIndex > 0 {
 		s.AddImportLabel(code.LabelIndex, s.CurPos)
 	}
-	if code.GotoIndex > 0 {
-		s.AddImportGoto(s.CurPos+position, code.GotoIndex)
+	if code.GotoIndex > 0 && !paramJumpRegistered && lastJumpPos > 0 {
+		s.AddImportGoto(lastJumpPos, code.GotoIndex)
 	}
 	if code.GlobalLabelIndex > 0 {
 		s.AddImportGlobalLabel(code.GlobalLabelIndex, s.CurPos)
 	}
-	if code.GlobalGotoIndex > 0 {
-		s.AddImportGlobalGoto(s.CurPos+position, code.GlobalGotoIndex)
+	if code.GlobalGotoIndex > 0 && !paramJumpRegistered && lastJumpPos > 0 {
+		s.AddImportGlobalGoto(lastJumpPos, code.GlobalGotoIndex)
 	}
 
 	s.CurPos += int(code.Len + code.Len&1)
@@ -476,6 +501,10 @@ func CodeString(w io.Writer, data string, hasLen bool, coding charset.Charset) i
 	}
 	buf := []byte(dst)
 	size := len(buf)
+	if hasLen && size == 0 {
+		binary.Write(w, binary.LittleEndian, uint16(0))
+		return 2
+	}
 	if hasLen {
 		writeSize := uint16(0)
 		switch coding {
@@ -530,9 +559,16 @@ func SetParam(buf *bytes.Buffer, param interface{}, coding charset.Charset, hasL
 		//if value.ScriptName != "" {
 		//	size += CodeString(buf, value.ScriptName, false, coding)
 		//}
-		if value.Position > 0 || value.GlobalIndex > 0 { // 现在为labelIndex
+		if value.Position > 0 || value.GlobalIndex > 0 || value.LabelIndex > 0 { // 现在为labelIndex
 			jump = true
-			binary.Write(buf, binary.LittleEndian, uint32(value.Position))
+			position := value.Position
+			if value.LabelIndex > 0 {
+				position = value.LabelIndex
+			}
+			if value.GlobalIndex > 0 {
+				position = value.GlobalIndex
+			}
+			binary.Write(buf, binary.LittleEndian, uint32(position))
 			size += 4
 		}
 	default:

--- a/script/util.go
+++ b/script/util.go
@@ -17,23 +17,20 @@ func ToStringCodeParams(code *CodeLine) string {
 		case byte:
 			paramStr = append(paramStr, fmt.Sprintf("0x%X", param))
 		case string:
-			esc := strings.ReplaceAll(param, `\`, `\\`)
-			esc = strings.ReplaceAll(esc, `"`, `\"`)
-			paramStr = append(paramStr, `"`+esc+`"`)
+			paramStr = append(paramStr, `"`+param+`"`)
 		case *JumpParam:
-			if param.ScriptName != "" && param.LabelIndex > 0 {
-				// external jump in another script file
-        scriptEsc := strings.ReplaceAll(param.ScriptName, `\`, `\\`)
-				scriptEsc = strings.ReplaceAll(scriptEsc, `"`, `\"`)
-        paramStr = append(paramStr, fmt.Sprintf(`{goto "%s" global%d}`, scriptEsc, param.LabelIndex))
-			} else if param.LabelIndex > 0 {
-				// internal jump in the same file
+			if param.LabelIndex > 0 {
 				paramStr = append(paramStr, fmt.Sprintf("{goto label%d}", param.LabelIndex))
+			} else if code.GotoIndex > 0 {
+				paramStr = append(paramStr, fmt.Sprintf("{goto label%d}", code.GotoIndex))
+			} else if param.GlobalIndex > 0 {
+				paramStr = append(paramStr, fmt.Sprintf(`{goto "%s" global%d}`, param.ScriptName, param.GlobalIndex))
 			} else {
 				paramStr = append(paramStr, fmt.Sprintf("{goto %d}", param.Position))
 			}
 		default:
 			paramStr = append(paramStr, fmt.Sprintf("%v", param))
+
 		}
 	}
 	str := strings.Join(paramStr, ", ")
@@ -56,29 +53,19 @@ func ParseCodeParams(code *CodeLine, codeStr string) {
 	globalLabelIndex := 0
 	globalGotoIndex := 0
 	gotoFile := ""
+	specialGotoIndex := 0
+	specialGlobalGotoIndex := 0
+	specialGotoFile := ""
 	isString := false
 	isSpecial := false
-	escaped := false
 
 	for _, ch := range codeStr {
 		if isString {
-			if escaped {
-				// add any char after '\' to the word
-				word = append(word, ch)
-				escaped = false
-				continue
-			}
-			if ch == '\\' {
-				// start of escape sequence
-				escaped = true
-				continue
-			}
 			if ch == '"' {
 				if len(word) == 0 { // 空字符串
 					word = append(word, '\x00')
 				}
 				isString = false
-				escaped = false
 				continue
 			}
 			word = append(word, ch)
@@ -96,11 +83,11 @@ func ParseCodeParams(code *CodeLine, codeStr string) {
 					opStr = wordStr
 				} else if isSpecial {
 					if len(word) > 5 && wordStr[0:5] == "label" {
-						gotoIndex, _ = strconv.Atoi(wordStr[5:])
+						specialGotoIndex, _ = strconv.Atoi(wordStr[5:])
 					} else if len(word) > 6 && wordStr[0:6] == "global" {
-						globalGotoIndex, _ = strconv.Atoi(wordStr[6:])
+						specialGlobalGotoIndex, _ = strconv.Atoi(wordStr[6:])
 					} else if wordStr != "goto" {
-						gotoFile = wordStr
+						specialGotoFile = wordStr
 					}
 				} else {
 					params = append(params, wordStr)
@@ -108,14 +95,27 @@ func ParseCodeParams(code *CodeLine, codeStr string) {
 				word = word[0:0]
 			}
 			if ch == '}' {
-				isSpecial = false
-				if gotoFile != "" || gotoIndex > 0 || globalGotoIndex > 0 {
+				if specialGotoFile != "" || specialGotoIndex > 0 || specialGlobalGotoIndex > 0 {
 					params = append(params, &JumpParam{
-						LabelIndex: globalGotoIndex,
-						ScriptName: gotoFile,
-						Position:   gotoIndex + globalGotoIndex,
+						GlobalIndex: specialGlobalGotoIndex,
+						LabelIndex:  specialGotoIndex,
+						ScriptName:  specialGotoFile,
+						Position:    specialGotoIndex + specialGlobalGotoIndex, // 填充使用
 					})
+					if gotoIndex == 0 && specialGotoIndex > 0 {
+						gotoIndex = specialGotoIndex
+					}
+					if globalGotoIndex == 0 && specialGlobalGotoIndex > 0 {
+						globalGotoIndex = specialGlobalGotoIndex
+					}
+					if gotoFile == "" && specialGotoFile != "" {
+						gotoFile = specialGotoFile
+					}
 				}
+				specialGotoIndex = 0
+				specialGlobalGotoIndex = 0
+				specialGotoFile = ""
+				isSpecial = false
 			}
 		case ':':
 			if len(word) > 5 && string(word[0:5]) == "label" {
@@ -126,12 +126,8 @@ func ParseCodeParams(code *CodeLine, codeStr string) {
 			word = word[0:0]
 		case '"':
 			isString = true
-			escaped = false
 		case '{':
 			isSpecial = true
-			gotoIndex = 0
-			globalGotoIndex = 0
-			gotoFile = ""
 		default:
 			word = append(word, ch)
 		}
@@ -143,6 +139,14 @@ func ParseCodeParams(code *CodeLine, codeStr string) {
 	code.GlobalGotoIndex = globalGotoIndex
 	code.GlobalLabelIndex = globalLabelIndex
 
+	if isSpecial && (specialGotoFile != "" || specialGotoIndex > 0 || specialGlobalGotoIndex > 0) {
+		params = append(params, &JumpParam{
+			GlobalIndex: specialGlobalGotoIndex,
+			LabelIndex:  specialGotoIndex,
+			ScriptName:  specialGotoFile,
+			Position:    specialGotoIndex + specialGlobalGotoIndex, // 填充使用
+		})
+	}
 	code.Params = params
 
 	// if labelIndex > 0 {


### PR DESCRIPTION
22/05/2026

## Fixed: AIR no longer crashes after font round-trip or Vietnamese charset injection

### Problem

AIR Steam accepted edited `FONT__INFO.PAK` files on their own, but crashed on startup as soon as the large English/Japanese `FONT_GOTHIC1.PAK` was rewritten, even with a no-op round-trip. The same edits also produced visual menu glitches when several font sizes or families were touched.

When Vietnamese glyphs were injected by replacing the tail of the original charset, missing characters started to appear, but early builds had two rendering problems:

- AIR's font PAK preload path was sensitive to rewritten PAK layout.
- Newly drawn Vietnamese glyphs used TTF vertical metrics directly, producing negative Y offsets and visible glyphs floating too high.

### Root cause

- `pak.Write()` copied the whole source PAK first. When replacements were smaller than the original slots and `Rebuild` was false, the output kept internal holes. When `Rebuild` was true, the file could still keep a stale copied tail unless it was explicitly truncated.
- AIR font info tables use the legacy layout `CharNum=100` plus `CharNum2=<real count>`. Loading normalized the count, but writing did not preserve that layout.
- Partial font replacement recomputed atlas dimensions from character count, which could shrink/reshape an atlas that AIR expected to stay byte-layout compatible.
- CZ2 import recompressed the alpha image using LuckSystem's generic block splitting. AIR tolerated some rewritten CZ2s, but the large Japanese Gothic atlas path proved stricter.
- Several Vietnamese characters already existed in AIR's charset (`á`, `ó`, `â`, etc.). Replacing them with newly drawn glyphs regressed their original metrics.

### Fix

**CLI / core**

- `font/info.go`
  - Preserve the `CharNum=100 + CharNum2` info layout on write when the source used it.
- `font/font.go`
  - Preserve original atlas dimensions during partial replacement.
  - Copy the old atlas first and redraw only the replaced cells.
- `czimage/cz2.go`, `czimage/util.go`
  - Preserve original CZ2 raw block boundaries when the edited image has the same total raw size.
- `pak/pak.go`
  - Support compact rebuilt PAKs with recalculated offsets.
  - Truncate rebuilt output to the aligned real end so stale bytes from the copied source PAK cannot remain.
  - 
  *GUI**

- Updated GUI title/about/version text to `v3.1.7`.
- Removed stale duplicate `frontend/src/dialogue.go`; the maintained dialogue extract/import implementation is in `app.go`. This prevents `go test ./...` from treating the frontend folder as a broken Go package.
- No GUI workflow change is required: the GUI remains a subprocess wrapper around the CLI. Existing Font Extract/Edit forms continue to use the patched core code once rebuilt with the new CLI.

**Maintenance**

- `game/runtime/global_goto.go`: fixed two `%s`/integer log format strings so `go test ./...` no longer fails Go vet on that package.